### PR TITLE
feat: add system prompt routing for interactive mode

### DIFF
--- a/.validator/config.yml
+++ b/.validator/config.yml
@@ -13,38 +13,27 @@ cli:
       allow_tool_use: false
       thinking_budget: high
 
-checks:
-  build:
-    command: go build ./...
-  lint:
-    command: golangci-lint run ./...
-  test:
-    command: go test ./...
-  security-code:
-    command: gosec ./...
-  security-deps:
-    command: govulncheck ./...
-
-reviews:
-  code-quality:
-    builtin: code-quality
-    model: claude-sonnet-4.6
-  security-and-errors:
-    builtin: security-and-errors
-    model: gpt-5.3-codex
-
 # entry_points configured by /validator-setup
 entry_points:
   - path: "."
     checks:
-      - build
-      - lint
-      - test
-      - security-code
-      - security-deps
+      - build:
+          command: go build ./...
+      - lint:
+          command: golangci-lint run ./...
+      - test:
+          command: go test ./...
+      - security-code:
+          command: gosec ./...
+      - security-deps:
+          command: govulncheck ./...
     reviews:
-      - code-quality
-      - security-and-errors
+      - code-quality:
+          builtin: code-quality
+          model: claude-sonnet-4.6
+      - security-and-errors:
+          builtin: security-and-errors
+          model: gpt-5.3-codex
 
 # -------------------------------------------------------------------
 # All settings below are optional. Uncomment and change as needed.

--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -298,7 +298,11 @@ func resolveWorkflowArg(arg string) (string, error) {
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return "", fmt.Errorf("stat %s: %w", ymlPath, err)
 	}
-	return "", fmt.Errorf("workflow %q not found (tried %s and %s)", arg, yamlPath, ymlPath)
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("workflow %q not found (tried %s and %s); failed to get cwd: %w", arg, yamlPath, ymlPath, err)
+	}
+	return "", fmt.Errorf("workflow %q not found in %s (tried %s and %s)", arg, cwd, yamlPath, ymlPath)
 }
 
 func handleRun(args []string) int {

--- a/internal/cli/adapter.go
+++ b/internal/cli/adapter.go
@@ -19,7 +19,7 @@ type BuildArgsInput struct {
 // Adapter abstracts CLI invocation for a specific agent backend.
 type Adapter interface {
 	// BuildArgs constructs the full command and args for invoking the CLI.
-	BuildArgs(input BuildArgsInput) []string
+	BuildArgs(input *BuildArgsInput) []string
 
 	// DiscoverSessionID returns a session ID after the CLI process exits.
 	// For some adapters this is deterministic (e.g. a pre-generated UUID),

--- a/internal/cli/adapter.go
+++ b/internal/cli/adapter.go
@@ -8,11 +8,12 @@ import (
 
 // BuildArgsInput provides the parameters needed to construct CLI invocation args.
 type BuildArgsInput struct {
-	Prompt    string
-	SessionID string // Session ID to pass to the CLI (pre-generated for new, or existing for resume)
-	Resume    bool   // True when resuming an existing session, false for fresh sessions
-	Model     string
-	Headless  bool
+	Prompt       string
+	SystemPrompt string // Content to deliver as a system prompt (for adapters that support it)
+	SessionID    string // Session ID to pass to the CLI (pre-generated for new, or existing for resume)
+	Resume       bool   // True when resuming an existing session, false for fresh sessions
+	Model        string
+	Headless     bool
 }
 
 // Adapter abstracts CLI invocation for a specific agent backend.
@@ -24,6 +25,10 @@ type Adapter interface {
 	// For some adapters this is deterministic (e.g. a pre-generated UUID),
 	// for others it requires parsing output or scanning the filesystem.
 	DiscoverSessionID(opts DiscoverOptions) string
+
+	// SupportsSystemPrompt reports whether this adapter can deliver content
+	// as a native system prompt (e.g. via --append-system-prompt).
+	SupportsSystemPrompt() bool
 }
 
 // DiscoverOptions provides context for session ID discovery after a CLI process exits.

--- a/internal/cli/adapter_test.go
+++ b/internal/cli/adapter_test.go
@@ -58,7 +58,7 @@ func TestClaudeAdapter(t *testing.T) {
 	adapter := &ClaudeAdapter{}
 
 	t.Run("fresh headless with session-id", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:    "do something",
 			SessionID: "uuid-123",
 			Headless:  true,
@@ -68,7 +68,7 @@ func TestClaudeAdapter(t *testing.T) {
 	})
 
 	t.Run("fresh interactive with session-id", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:    "review code",
 			SessionID: "uuid-456",
 			Headless:  false,
@@ -78,7 +78,7 @@ func TestClaudeAdapter(t *testing.T) {
 	})
 
 	t.Run("fresh headless without session-id", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:   "do something",
 			Headless: true,
 		})
@@ -87,7 +87,7 @@ func TestClaudeAdapter(t *testing.T) {
 	})
 
 	t.Run("resume headless", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:    "continue",
 			SessionID: "session-abc",
 			Resume:    true,
@@ -98,7 +98,7 @@ func TestClaudeAdapter(t *testing.T) {
 	})
 
 	t.Run("resume interactive", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:    "continue review",
 			SessionID: "session-abc",
 			Resume:    true,
@@ -109,7 +109,7 @@ func TestClaudeAdapter(t *testing.T) {
 	})
 
 	t.Run("model override", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:   "do something",
 			Model:    "opus",
 			Headless: true,
@@ -119,7 +119,7 @@ func TestClaudeAdapter(t *testing.T) {
 	})
 
 	t.Run("resume with model override", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:    "continue",
 			SessionID: "session-abc",
 			Resume:    true,
@@ -137,7 +137,7 @@ func TestClaudeAdapter(t *testing.T) {
 	})
 
 	t.Run("interactive with system prompt emits --append-system-prompt", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			SystemPrompt: "you are helpful",
 			SessionID:    "uuid-789",
 			Headless:     false,
@@ -147,7 +147,7 @@ func TestClaudeAdapter(t *testing.T) {
 	})
 
 	t.Run("system prompt with headless prompt emits both", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:       "do something",
 			SystemPrompt: "extra context",
 			SessionID:    "uuid-abc",
@@ -158,7 +158,7 @@ func TestClaudeAdapter(t *testing.T) {
 	})
 
 	t.Run("no system prompt omits flag", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:   "do something",
 			Headless: true,
 		})
@@ -190,7 +190,7 @@ func TestCodexAdapter(t *testing.T) {
 	adapter := &CodexAdapter{}
 
 	t.Run("fresh headless", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:   "do something",
 			Headless: true,
 		})
@@ -199,7 +199,7 @@ func TestCodexAdapter(t *testing.T) {
 	})
 
 	t.Run("fresh interactive", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:   "review code",
 			Headless: false,
 		})
@@ -208,7 +208,7 @@ func TestCodexAdapter(t *testing.T) {
 	})
 
 	t.Run("resume headless", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:    "continue",
 			SessionID: "thread-abc",
 			Headless:  true,
@@ -218,7 +218,7 @@ func TestCodexAdapter(t *testing.T) {
 	})
 
 	t.Run("resume interactive", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:    "continue review",
 			SessionID: "thread-abc",
 			Headless:  false,
@@ -228,7 +228,7 @@ func TestCodexAdapter(t *testing.T) {
 	})
 
 	t.Run("model override headless", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:   "do something",
 			Model:    "o3",
 			Headless: true,
@@ -238,7 +238,7 @@ func TestCodexAdapter(t *testing.T) {
 	})
 
 	t.Run("model override interactive", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:   "review",
 			Model:    "o3",
 			Headless: false,
@@ -254,7 +254,7 @@ func TestCodexAdapter(t *testing.T) {
 	})
 
 	t.Run("ignores system prompt field", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:       "do something",
 			SystemPrompt: "should be ignored",
 			Headless:     true,
@@ -264,7 +264,7 @@ func TestCodexAdapter(t *testing.T) {
 	})
 
 	t.Run("interactive always includes --no-alt-screen", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:   "review",
 			Headless: false,
 		})
@@ -280,7 +280,7 @@ func TestCodexAdapter(t *testing.T) {
 	})
 
 	t.Run("headless does not include --no-alt-screen", func(t *testing.T) {
-		args := adapter.BuildArgs(BuildArgsInput{
+		args := adapter.BuildArgs(&BuildArgsInput{
 			Prompt:   "do something",
 			Headless: true,
 		})

--- a/internal/cli/adapter_test.go
+++ b/internal/cli/adapter_test.go
@@ -130,6 +130,45 @@ func TestClaudeAdapter(t *testing.T) {
 		assertArgs(t, expected, args)
 	})
 
+	t.Run("supports system prompt", func(t *testing.T) {
+		if !adapter.SupportsSystemPrompt() {
+			t.Fatal("expected Claude adapter to support system prompt")
+		}
+	})
+
+	t.Run("interactive with system prompt emits --append-system-prompt", func(t *testing.T) {
+		args := adapter.BuildArgs(BuildArgsInput{
+			SystemPrompt: "you are helpful",
+			SessionID:    "uuid-789",
+			Headless:     false,
+		})
+		expected := []string{"claude", "--session-id", "uuid-789", "--append-system-prompt", "you are helpful", ""}
+		assertArgs(t, expected, args)
+	})
+
+	t.Run("system prompt with headless prompt emits both", func(t *testing.T) {
+		args := adapter.BuildArgs(BuildArgsInput{
+			Prompt:       "do something",
+			SystemPrompt: "extra context",
+			SessionID:    "uuid-abc",
+			Headless:     true,
+		})
+		expected := []string{"claude", "--session-id", "uuid-abc", "-p", "--append-system-prompt", "extra context", "do something"}
+		assertArgs(t, expected, args)
+	})
+
+	t.Run("no system prompt omits flag", func(t *testing.T) {
+		args := adapter.BuildArgs(BuildArgsInput{
+			Prompt:   "do something",
+			Headless: true,
+		})
+		for _, a := range args {
+			if a == "--append-system-prompt" {
+				t.Fatalf("did not expect --append-system-prompt when SystemPrompt is empty, got %v", args)
+			}
+		}
+	})
+
 	t.Run("discover session ID returns preset", func(t *testing.T) {
 		id := adapter.DiscoverSessionID(DiscoverOptions{
 			PresetID: "preset-123",
@@ -205,6 +244,22 @@ func TestCodexAdapter(t *testing.T) {
 			Headless: false,
 		})
 		expected := []string{"codex", "--no-alt-screen", "-m", "o3", "review"}
+		assertArgs(t, expected, args)
+	})
+
+	t.Run("does not support system prompt", func(t *testing.T) {
+		if adapter.SupportsSystemPrompt() {
+			t.Fatal("expected Codex adapter to not support system prompt")
+		}
+	})
+
+	t.Run("ignores system prompt field", func(t *testing.T) {
+		args := adapter.BuildArgs(BuildArgsInput{
+			Prompt:       "do something",
+			SystemPrompt: "should be ignored",
+			Headless:     true,
+		})
+		expected := []string{"codex", "exec", "--json", "do something"}
 		assertArgs(t, expected, args)
 	})
 

--- a/internal/cli/adapter_test.go
+++ b/internal/cli/adapter_test.go
@@ -142,7 +142,7 @@ func TestClaudeAdapter(t *testing.T) {
 			SessionID:    "uuid-789",
 			Headless:     false,
 		})
-		expected := []string{"claude", "--session-id", "uuid-789", "--append-system-prompt", "you are helpful", ""}
+		expected := []string{"claude", "--session-id", "uuid-789", "--append-system-prompt", "you are helpful"}
 		assertArgs(t, expected, args)
 	})
 

--- a/internal/cli/claude.go
+++ b/internal/cli/claude.go
@@ -34,7 +34,9 @@ func (a *ClaudeAdapter) BuildArgs(input *BuildArgsInput) []string {
 		args = append(args, "--append-system-prompt", input.SystemPrompt)
 	}
 
-	args = append(args, input.Prompt)
+	if input.Prompt != "" {
+		args = append(args, input.Prompt)
+	}
 	return args
 }
 

--- a/internal/cli/claude.go
+++ b/internal/cli/claude.go
@@ -11,7 +11,7 @@ type ClaudeAdapter struct{}
 //   - Resume interactive: claude --resume <uuid> <prompt>
 //   - Resume headless:    claude --resume <uuid> -p <prompt>
 //   - Model override:     appends --model <m>
-func (a *ClaudeAdapter) BuildArgs(input BuildArgsInput) []string {
+func (a *ClaudeAdapter) BuildArgs(input *BuildArgsInput) []string {
 	args := []string{"claude"}
 
 	if input.SessionID != "" {

--- a/internal/cli/claude.go
+++ b/internal/cli/claude.go
@@ -30,8 +30,17 @@ func (a *ClaudeAdapter) BuildArgs(input BuildArgsInput) []string {
 		args = append(args, "-p")
 	}
 
+	if input.SystemPrompt != "" {
+		args = append(args, "--append-system-prompt", input.SystemPrompt)
+	}
+
 	args = append(args, input.Prompt)
 	return args
+}
+
+// SupportsSystemPrompt returns true — Claude CLI supports --append-system-prompt.
+func (a *ClaudeAdapter) SupportsSystemPrompt() bool {
+	return true
 }
 
 // DiscoverSessionID returns the pre-generated session ID.

--- a/internal/cli/codex.go
+++ b/internal/cli/codex.go
@@ -47,6 +47,11 @@ func (a *CodexAdapter) BuildArgs(input BuildArgsInput) []string {
 	return args
 }
 
+// SupportsSystemPrompt returns false — Codex CLI has no native system prompt flag.
+func (a *CodexAdapter) SupportsSystemPrompt() bool {
+	return false
+}
+
 // DiscoverSessionID returns the session ID after a Codex process exits.
 // For headless mode, it parses the thread_id from the thread.started JSONL event.
 // For interactive mode, it scans ~/.codex/sessions/ for the most recent session file.

--- a/internal/cli/codex.go
+++ b/internal/cli/codex.go
@@ -21,7 +21,7 @@ type CodexAdapter struct{}
 //   - Resume interactive: codex resume --no-alt-screen <uuid> <prompt>
 //   - Resume headless:    codex exec resume <uuid> <prompt>
 //   - Model override:     appends -m <m>
-func (a *CodexAdapter) BuildArgs(input BuildArgsInput) []string {
+func (a *CodexAdapter) BuildArgs(input *BuildArgsInput) []string {
 	args := []string{"codex"}
 
 	if input.Headless {

--- a/internal/exec/agent.go
+++ b/internal/exec/agent.go
@@ -48,13 +48,27 @@ func ExecuteAgentStep(
 	}
 
 	headless := mode == model.ModeHeadless
-	args := adapter.BuildArgs(cli.BuildArgsInput{
-		Prompt:    prompt,
+	fullPrompt := prompt
+	if enrichment != "" {
+		fullPrompt = prompt + "\n\n" + enrichment
+	}
+
+	input := cli.BuildArgsInput{
 		SessionID: sessionID,
 		Resume:    isResume,
 		Model:     step.Model,
 		Headless:  headless,
-	})
+	}
+
+	if headless {
+		input.Prompt = fullPrompt
+	} else if adapter.SupportsSystemPrompt() {
+		input.SystemPrompt = fullPrompt
+	} else {
+		input.Prompt = "<system>\n" + fullPrompt + "\n</system>"
+	}
+
+	args := adapter.BuildArgs(input)
 
 	emitAgentStart(ctx, prefix, startTime, prompt, mode, step, sessionID, cliName, enrichment)
 	logAgentStep(log, mode, prompt)
@@ -232,7 +246,6 @@ func buildAgentPrompt(step *model.Step, ctx *model.ExecutionContext) (prompt, en
 		})
 		if result != "" {
 			enrichment = result
-			prompt = prompt + "\n\n" + enrichment
 		}
 	}
 

--- a/internal/exec/agent.go
+++ b/internal/exec/agent.go
@@ -60,15 +60,16 @@ func ExecuteAgentStep(
 		Headless:  headless,
 	}
 
-	if headless {
+	switch {
+	case headless:
 		input.Prompt = fullPrompt
-	} else if adapter.SupportsSystemPrompt() {
+	case adapter.SupportsSystemPrompt():
 		input.SystemPrompt = fullPrompt
-	} else {
+	default:
 		input.Prompt = "<system>\n" + fullPrompt + "\n</system>"
 	}
 
-	args := adapter.BuildArgs(input)
+	args := adapter.BuildArgs(&input)
 
 	emitAgentStart(ctx, prefix, startTime, prompt, mode, step, sessionID, cliName, enrichment)
 	logAgentStep(log, mode, prompt)

--- a/internal/exec/agent.go
+++ b/internal/exec/agent.go
@@ -63,10 +63,13 @@ func ExecuteAgentStep(
 	switch {
 	case headless:
 		input.Prompt = fullPrompt
+	case enrichment == "":
+		input.Prompt = prompt
 	case adapter.SupportsSystemPrompt():
-		input.SystemPrompt = fullPrompt
+		input.Prompt = prompt
+		input.SystemPrompt = enrichment
 	default:
-		input.Prompt = "<system>\n" + fullPrompt + "\n</system>"
+		input.Prompt = "<system>\n" + enrichment + "\n</system>\n\n" + prompt
 	}
 
 	args := adapter.BuildArgs(&input)

--- a/internal/exec/agent_test.go
+++ b/internal/exec/agent_test.go
@@ -344,6 +344,84 @@ func TestExecuteAgentStep(t *testing.T) {
 			t.Fatalf("expected no RunAgent calls for interactive step, got %d", len(runner.calls))
 		}
 	})
+
+	t.Run("interactive claude uses system prompt instead of positional arg", func(t *testing.T) {
+		var ptyCalls [][]string
+		oldFn := interactiveRunnerFn
+		interactiveRunnerFn = func(args []string, _ pty.Options) (pty.Result, error) {
+			ptyCalls = append(ptyCalls, args)
+			return pty.Result{ContinueTriggered: true}, nil
+		}
+		defer func() { interactiveRunnerFn = oldFn }()
+
+		runner := &mockRunner{}
+		step := model.Step{ID: "s", Mode: model.ModeInteractive, Prompt: "review code", Session: model.SessionNew}
+		ExecuteAgentStep(&step, makeCtx(), runner, &mockLogger{})
+		if len(ptyCalls) == 0 {
+			t.Fatal("expected PTY to be called")
+		}
+		args := ptyCalls[0]
+		if !containsArg(args, "--append-system-prompt") {
+			t.Fatalf("expected --append-system-prompt for interactive claude, got %v", args)
+		}
+		// Last arg should be empty (no positional prompt)
+		if args[len(args)-1] != "" {
+			t.Fatalf("expected empty positional prompt for interactive claude with system prompt, got %q", args[len(args)-1])
+		}
+	})
+
+	t.Run("interactive codex wraps prompt in system XML tags", func(t *testing.T) {
+		var ptyCalls [][]string
+		oldFn := interactiveRunnerFn
+		interactiveRunnerFn = func(args []string, _ pty.Options) (pty.Result, error) {
+			ptyCalls = append(ptyCalls, args)
+			return pty.Result{ContinueTriggered: true}, nil
+		}
+		defer func() { interactiveRunnerFn = oldFn }()
+
+		runner := &mockRunner{}
+		step := model.Step{ID: "s", Mode: model.ModeInteractive, Prompt: "review code", Session: model.SessionNew, CLI: "codex"}
+		ExecuteAgentStep(&step, makeCtx(), runner, &mockLogger{})
+		if len(ptyCalls) == 0 {
+			t.Fatal("expected PTY to be called")
+		}
+		args := ptyCalls[0]
+		lastArg := args[len(args)-1]
+		if !strings.HasPrefix(lastArg, "<system>\n") || !strings.HasSuffix(lastArg, "\n</system>") {
+			t.Fatalf("expected <system> XML wrapping for codex interactive, got %q", lastArg)
+		}
+		if !strings.Contains(lastArg, "review code") {
+			t.Fatalf("expected prompt content inside XML tags, got %q", lastArg)
+		}
+	})
+
+	t.Run("headless mode passes prompt as positional arg without wrapping", func(t *testing.T) {
+		runner := &mockRunner{results: []ProcessResult{{ExitCode: 0}}}
+		step := model.Step{ID: "s", Mode: model.ModeHeadless, Prompt: "implement feature", Session: model.SessionNew}
+		ExecuteAgentStep(&step, makeCtx(), runner, &mockLogger{})
+		args := runner.calls[0]
+		lastArg := args[len(args)-1]
+		if lastArg != "implement feature" {
+			t.Fatalf("expected plain prompt for headless, got %q", lastArg)
+		}
+		if containsArg(args, "--append-system-prompt") {
+			t.Fatalf("did not expect --append-system-prompt for headless mode, got %v", args)
+		}
+	})
+
+	t.Run("headless codex passes prompt without XML wrapping", func(t *testing.T) {
+		runner := &mockRunner{results: []ProcessResult{{ExitCode: 0}}}
+		step := model.Step{ID: "s", Mode: model.ModeHeadless, Prompt: "implement feature", Session: model.SessionNew, CLI: "codex"}
+		ExecuteAgentStep(&step, makeCtx(), runner, &mockLogger{})
+		args := runner.calls[0]
+		lastArg := args[len(args)-1]
+		if lastArg != "implement feature" {
+			t.Fatalf("expected plain prompt for headless codex, got %q", lastArg)
+		}
+		if strings.Contains(lastArg, "<system>") {
+			t.Fatalf("did not expect XML wrapping for headless mode, got %q", lastArg)
+		}
+	})
 }
 
 func containsArg(args []string, target string) bool {

--- a/internal/exec/agent_test.go
+++ b/internal/exec/agent_test.go
@@ -364,9 +364,11 @@ func TestExecuteAgentStep(t *testing.T) {
 		if !containsArg(args, "--append-system-prompt") {
 			t.Fatalf("expected --append-system-prompt for interactive claude, got %v", args)
 		}
-		// Last arg should be empty (no positional prompt)
-		if args[len(args)-1] != "" {
-			t.Fatalf("expected empty positional prompt for interactive claude with system prompt, got %q", args[len(args)-1])
+		// No positional prompt argument — last arg should be the system prompt value, not empty
+		for i, a := range args {
+			if a == "" && i == len(args)-1 {
+				t.Fatal("expected no trailing empty positional prompt for interactive claude with system prompt")
+			}
 		}
 	})
 

--- a/internal/exec/agent_test.go
+++ b/internal/exec/agent_test.go
@@ -345,7 +345,7 @@ func TestExecuteAgentStep(t *testing.T) {
 		}
 	})
 
-	t.Run("interactive claude uses system prompt instead of positional arg", func(t *testing.T) {
+	t.Run("interactive claude without enrichment passes prompt positionally", func(t *testing.T) {
 		var ptyCalls [][]string
 		oldFn := interactiveRunnerFn
 		interactiveRunnerFn = func(args []string, _ pty.Options) (pty.Result, error) {
@@ -361,18 +361,16 @@ func TestExecuteAgentStep(t *testing.T) {
 			t.Fatal("expected PTY to be called")
 		}
 		args := ptyCalls[0]
-		if !containsArg(args, "--append-system-prompt") {
-			t.Fatalf("expected --append-system-prompt for interactive claude, got %v", args)
+		lastArg := args[len(args)-1]
+		if lastArg != "review code" {
+			t.Fatalf("expected prompt as positional arg, got %q", lastArg)
 		}
-		// No positional prompt argument — last arg should be the system prompt value, not empty
-		for i, a := range args {
-			if a == "" && i == len(args)-1 {
-				t.Fatal("expected no trailing empty positional prompt for interactive claude with system prompt")
-			}
+		if containsArg(args, "--append-system-prompt") {
+			t.Fatal("did not expect --append-system-prompt without enrichment")
 		}
 	})
 
-	t.Run("interactive codex wraps prompt in system XML tags", func(t *testing.T) {
+	t.Run("interactive codex without enrichment passes prompt positionally", func(t *testing.T) {
 		var ptyCalls [][]string
 		oldFn := interactiveRunnerFn
 		interactiveRunnerFn = func(args []string, _ pty.Options) (pty.Result, error) {
@@ -389,11 +387,8 @@ func TestExecuteAgentStep(t *testing.T) {
 		}
 		args := ptyCalls[0]
 		lastArg := args[len(args)-1]
-		if !strings.HasPrefix(lastArg, "<system>\n") || !strings.HasSuffix(lastArg, "\n</system>") {
-			t.Fatalf("expected <system> XML wrapping for codex interactive, got %q", lastArg)
-		}
-		if !strings.Contains(lastArg, "review code") {
-			t.Fatalf("expected prompt content inside XML tags, got %q", lastArg)
+		if lastArg != "review code" {
+			t.Fatalf("expected prompt as positional arg for codex without enrichment, got %q", lastArg)
 		}
 	})
 

--- a/openspec/changes/system-prompt/.openspec.yaml
+++ b/openspec/changes/system-prompt/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-04

--- a/openspec/changes/system-prompt/design.md
+++ b/openspec/changes/system-prompt/design.md
@@ -1,0 +1,105 @@
+## Context
+
+Today, `buildAgentPrompt` in `internal/exec/agent.go` concatenates the step prompt and engine enrichment into a single string, passed as the positional CLI argument. In interactive mode, this appears as the first user message — cluttering the session with long instructions the user didn't write. Claude Code supports `--append-system-prompt` to deliver content invisibly as a system prompt; Codex does not.
+
+The specs define three routing modes:
+- **Interactive + native support**: full content via system prompt mechanism, no positional arg
+- **Interactive + no support**: full content wrapped in `<system>` XML tags as positional arg
+- **Headless**: concatenated into positional arg unchanged (current behavior)
+
+## Goals / Non-Goals
+
+**Goals:**
+- Route prompt content as a system prompt in interactive mode for adapters that support it
+- Provide a structured XML fallback for adapters that don't
+- Keep headless mode behavior unchanged
+
+**Non-Goals:**
+- Changing the engine's `enrichPrompt` interface (it still returns a string)
+- Supporting per-step opt-in/opt-out of system prompt routing
+- Changing headless mode behavior
+
+## Approach
+
+Three changes, all localized:
+
+### 1. Adapter interface additions (`internal/cli/adapter.go`)
+
+Add `SupportsSystemPrompt() bool` to the `Adapter` interface. Add `SystemPrompt string` to `BuildArgsInput`.
+
+```go
+type Adapter interface {
+    BuildArgs(input BuildArgsInput) []string
+    DiscoverSessionID(opts DiscoverOptions) string
+    SupportsSystemPrompt() bool
+}
+
+type BuildArgsInput struct {
+    Prompt       string
+    SystemPrompt string
+    SessionID    string
+    Resume       bool
+    Model        string
+    Headless     bool
+}
+```
+
+### 2. Adapter implementations
+
+**Claude (`internal/cli/claude.go`):**
+- `SupportsSystemPrompt()` returns `true`
+- `BuildArgs` emits `--append-system-prompt <content>` when `SystemPrompt` is non-empty
+
+**Codex (`internal/cli/codex.go`):**
+- `SupportsSystemPrompt()` returns `false`
+- `BuildArgs` ignores the `SystemPrompt` field
+
+### 3. Routing logic in `internal/exec/agent.go`
+
+**`buildAgentPrompt` stops concatenating.** Currently it does `prompt = prompt + "\n\n" + enrichment`. Change: return step prompt and enrichment as separate strings. The function signature stays `(prompt, enrichment string, err error)` but `prompt` no longer includes enrichment.
+
+**Inline routing at the `BuildArgsInput` construction site** (~line 51):
+
+```go
+stepPrompt, enrichment, err := buildAgentPrompt(step, ctx)
+// ...
+fullPrompt := stepPrompt
+if enrichment != "" {
+    fullPrompt = stepPrompt + "\n\n" + enrichment
+}
+
+input := cli.BuildArgsInput{
+    SessionID: sessionID,
+    Resume:    isResume,
+    Model:     step.Model,
+    Headless:  headless,
+}
+
+if headless {
+    input.Prompt = fullPrompt
+} else if adapter.SupportsSystemPrompt() {
+    input.SystemPrompt = fullPrompt
+} else {
+    input.Prompt = "<system>\n" + fullPrompt + "\n</system>"
+}
+```
+
+## Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| `SupportsSystemPrompt() bool` method over returning the flag name | Keeps CLI-specific details (flag names) inside the adapter. The caller only needs a yes/no answer. |
+| Inline routing over a helper function | Single call site, ~10 lines of straightforward if/else. A helper would be premature abstraction. |
+| `buildAgentPrompt` keeps its signature, stops concatenating | Minimal change. The caller takes over composition, which it needs to do for routing anyway. |
+| `<system>` XML tag for fallback wrapping | Common LLM prompting convention for structural delimiters. No closing rationale needed for the tag name — it's descriptive and unambiguous. |
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| Codex sessions now get `<system>` XML wrapping they didn't have before | LLMs treat XML tags as structural delimiters. Verify manually that Codex behavior is unaffected. |
+| Claude interactive sessions start with no positional arg (just system prompt) | Claude Code supports this — sessions begin with system prompt context and wait for user interaction. |
+
+## Open Questions
+
+None — all deferred-to-design items resolved.

--- a/openspec/changes/system-prompt/proposal.md
+++ b/openspec/changes/system-prompt/proposal.md
@@ -1,0 +1,31 @@
+# Proposal: System Prompt Support for CLI Adapters
+
+## Why
+
+Engine enrichment (workflow context, artifact instructions, dependency content) is currently passed as part of the user-visible prompt. This clutters the interactive session with long preambles the user didn't write and doesn't need to see. Claude Code supports `--append-system-prompt` to deliver instructions invisibly as a system prompt; we should use it where available.
+
+## What Changes
+
+- Add a `SystemPrompt` field to `BuildArgsInput` so adapters can receive enrichment separately from the user prompt.
+- **Claude adapter**: when `SystemPrompt` is non-empty, pass it via `--append-system-prompt` instead of concatenating it into the positional prompt argument.
+- **Codex adapter**: no change — Codex does not support a system prompt flag, so enrichment continues to be concatenated into the user-visible prompt.
+- `buildAgentPrompt` splits its return into user prompt and enrichment, routing enrichment to `SystemPrompt` instead of concatenating unconditionally.
+
+## Capabilities
+
+### New Capabilities
+
+- `system-prompt-delivery` — Adapter-level support for passing engine enrichment as a hidden system prompt when the underlying CLI supports it.
+
+### Modified Capabilities
+
+- `cli-adapter` — `BuildArgsInput` gains a `SystemPrompt` field; adapters that support it use it, others ignore it.
+- `engine-interface` — Enrichment is no longer unconditionally concatenated into the prompt; it is returned separately and routed to the adapter's system prompt channel.
+
+## Impact
+
+- **`internal/cli/adapter.go`**: `BuildArgsInput` struct gains `SystemPrompt string` field.
+- **`internal/cli/claude.go`**: `BuildArgs` emits `--append-system-prompt <text>` when system prompt is provided.
+- **`internal/cli/codex.go`**: No change (falls back to prompt concatenation).
+- **`internal/exec/agent.go`**: `buildAgentPrompt` returns prompt and enrichment separately; caller routes enrichment to `SystemPrompt` on the adapter input.
+- **Existing tests**: Adapter tests need updated expectations for the new flag; `buildAgentPrompt` tests need to verify separation.

--- a/openspec/changes/system-prompt/proposal.md
+++ b/openspec/changes/system-prompt/proposal.md
@@ -8,7 +8,7 @@ Engine enrichment (workflow context, artifact instructions, dependency content) 
 
 - Add a `SystemPrompt` field to `BuildArgsInput` so adapters can receive enrichment separately from the user prompt.
 - **Claude adapter**: when `SystemPrompt` is non-empty, pass it via `--append-system-prompt` instead of concatenating it into the positional prompt argument.
-- **Codex adapter**: no change — Codex does not support a system prompt flag, so enrichment continues to be concatenated into the user-visible prompt.
+- **Codex adapter**: no native system prompt support — enrichment is wrapped in `<system>` XML tags and prepended to the positional prompt.
 - `buildAgentPrompt` splits its return into user prompt and enrichment, routing enrichment to `SystemPrompt` instead of concatenating unconditionally.
 
 ## Capabilities
@@ -26,6 +26,6 @@ Engine enrichment (workflow context, artifact instructions, dependency content) 
 
 - **`internal/cli/adapter.go`**: `BuildArgsInput` struct gains `SystemPrompt string` field.
 - **`internal/cli/claude.go`**: `BuildArgs` emits `--append-system-prompt <text>` when system prompt is provided.
-- **`internal/cli/codex.go`**: No change (falls back to prompt concatenation).
+- **`internal/cli/codex.go`**: No change (enrichment is wrapped in `<system>` XML tags by the caller).
 - **`internal/exec/agent.go`**: `buildAgentPrompt` returns prompt and enrichment separately; caller routes enrichment to `SystemPrompt` on the adapter input.
 - **Existing tests**: Adapter tests need updated expectations for the new flag; `buildAgentPrompt` tests need to verify separation.

--- a/openspec/changes/system-prompt/specs/cli-adapter/spec.md
+++ b/openspec/changes/system-prompt/specs/cli-adapter/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Adapter system prompt capability
+
+Each adapter SHALL declare whether it supports native system prompt delivery. The Claude adapter SHALL declare support. The Codex adapter SHALL declare no support.
+
+Adapters declare support via a `SupportsSystemPrompt() bool` method on the `Adapter` interface. The caller queries this before constructing `BuildArgsInput`, setting the `SystemPrompt` field only when the adapter supports it.
+
+#### Scenario: Claude adapter declares support
+- **WHEN** the runner queries the Claude adapter for system prompt capability
+- **THEN** the adapter indicates it supports native system prompts
+
+#### Scenario: Codex adapter declares no support
+- **WHEN** the runner queries the Codex adapter for system prompt capability
+- **THEN** the adapter indicates it does not support native system prompts
+
+## MODIFIED Requirements
+
+### Requirement: Adapter arg construction
+
+Each adapter SHALL construct the CLI invocation args for both headless and interactive modes. The adapter receives the prompt, system prompt content (if applicable), session ID (if resuming), and model override (if specified), and returns the full command and args. When system prompt content is provided and the adapter supports it, the adapter SHALL include the appropriate CLI flags to deliver it as a system prompt (e.g., `--append-system-prompt` for Claude).
+
+#### Scenario: Headless invocation with model override
+- **WHEN** the runner executes a headless step with `model: sonnet` and a session ID from state
+- **THEN** the adapter returns args that include the prompt, model flag, session resume flag, and headless flag appropriate to that CLI
+
+#### Scenario: Interactive invocation with no session
+- **WHEN** the runner executes an interactive step with session strategy `new`
+- **THEN** the adapter returns args for a fresh interactive session (no resume flag)
+
+#### Scenario: Interactive invocation with system prompt (Claude)
+- **WHEN** the runner provides system prompt content to the Claude adapter for an interactive step
+- **THEN** the adapter includes `--append-system-prompt` with the content in the args
+
+#### Scenario: System prompt content provided to unsupporting adapter
+- **WHEN** the runner provides system prompt content to an adapter that does not support it
+- **THEN** the adapter ignores the system prompt field (the runner handles fallback wrapping)

--- a/openspec/changes/system-prompt/specs/engine-interface/spec.md
+++ b/openspec/changes/system-prompt/specs/engine-interface/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Prompt enrichment
+
+For steps whose ID matches an engine-managed artifact, baton SHALL call the engine's `enrichPrompt` (if implemented) to obtain engine-provided context. The enrichment SHALL be kept separate from the step prompt and delivered according to the system prompt routing rules: via native system prompt for supporting adapters in interactive mode, wrapped in `<system>` XML tags for non-supporting adapters in interactive mode, or concatenated into the positional argument for headless mode. The engine determines which step IDs it manages.
+
+#### Scenario: Step ID matches an engine artifact
+- **WHEN** a step's ID matches an engine-managed artifact and the engine implements `enrichPrompt`
+- **THEN** baton calls `enrichPrompt` and delivers the result separately from the step prompt via system prompt routing
+
+#### Scenario: Step ID does not match any engine artifact
+- **WHEN** a step's ID does not match any engine-managed artifact
+- **THEN** baton uses the step's prompt as-is, without calling `enrichPrompt`
+
+#### Scenario: Engine does not implement enrichPrompt
+- **WHEN** the engine does not implement `enrichPrompt`
+- **THEN** baton uses the step's prompt as-is

--- a/openspec/changes/system-prompt/specs/system-prompt-delivery/spec.md
+++ b/openspec/changes/system-prompt/specs/system-prompt-delivery/spec.md
@@ -2,24 +2,24 @@
 
 ### Requirement: System prompt routing
 
-For interactive mode, the runner SHALL deliver the full prompt content (step prompt and engine enrichment, concatenated) as a system prompt rather than a user-visible message. When the adapter supports native system prompts, the runner SHALL pass the full content via the adapter's system prompt mechanism. When the adapter does not support native system prompts, the runner SHALL wrap the full content in `<system>` XML tags and pass it as the positional argument. Headless mode SHALL continue using the positional argument with no wrapping (current behavior).
+For interactive mode with enrichment, the runner SHALL deliver only the enrichment as a system prompt, keeping the step prompt as a positional argument. When the adapter supports native system prompts, the runner SHALL pass enrichment via the adapter's system prompt mechanism and the step prompt as the positional argument. When the adapter does not support native system prompts, the runner SHALL wrap enrichment in `<system>` XML tags, prepend it to the step prompt, and pass the combined text as the positional argument. Headless mode SHALL continue concatenating prompt and enrichment into the positional argument with no wrapping (current behavior).
 
-#### Scenario: Adapter supports system prompt (interactive)
-- **WHEN** executing an interactive step and the adapter declares system prompt support
-- **THEN** the runner passes the full prompt content (step prompt + enrichment) via the adapter's system prompt mechanism, with no positional argument
+#### Scenario: Adapter supports system prompt (interactive with enrichment)
+- **WHEN** executing an interactive step with enrichment and the adapter declares system prompt support
+- **THEN** the runner passes enrichment via the adapter's system prompt mechanism and the step prompt as the positional argument
 
-#### Scenario: Adapter does not support system prompt (interactive)
-- **WHEN** executing an interactive step and the adapter does not support system prompts
-- **THEN** the runner wraps the full prompt content in `<system>` XML tags and passes it as the positional argument
+#### Scenario: Adapter does not support system prompt (interactive with enrichment)
+- **WHEN** executing an interactive step with enrichment and the adapter does not support system prompts
+- **THEN** the runner wraps enrichment in `<system>` XML tags, prepends it to the step prompt, and passes the combined text as the positional argument
 
 #### Scenario: Headless mode bypasses routing
 - **WHEN** executing a headless step regardless of adapter support
-- **THEN** the full prompt content is passed as the positional argument without wrapping (current behavior)
+- **THEN** prompt and enrichment are concatenated and passed as the positional argument without wrapping (current behavior)
 
-#### Scenario: No enrichment
-- **WHEN** no engine enrichment is returned for a step
-- **THEN** the step prompt alone is subject to the same routing rules
+#### Scenario: No enrichment (interactive)
+- **WHEN** no engine enrichment is returned for an interactive step
+- **THEN** the step prompt is passed as the positional argument with no system prompt routing
 
 #### Scenario: No step prompt
 - **WHEN** a step has no prompt
-- **THEN** the runner skips the step (current behavior, unchanged)
+- **THEN** the runner returns a failed outcome (current behavior, unchanged)

--- a/openspec/changes/system-prompt/specs/system-prompt-delivery/spec.md
+++ b/openspec/changes/system-prompt/specs/system-prompt-delivery/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: System prompt routing
+
+For interactive mode, the runner SHALL deliver the full prompt content (step prompt and engine enrichment, concatenated) as a system prompt rather than a user-visible message. When the adapter supports native system prompts, the runner SHALL pass the full content via the adapter's system prompt mechanism. When the adapter does not support native system prompts, the runner SHALL wrap the full content in `<system>` XML tags and pass it as the positional argument. Headless mode SHALL continue using the positional argument with no wrapping (current behavior).
+
+#### Scenario: Adapter supports system prompt (interactive)
+- **WHEN** executing an interactive step and the adapter declares system prompt support
+- **THEN** the runner passes the full prompt content (step prompt + enrichment) via the adapter's system prompt mechanism, with no positional argument
+
+#### Scenario: Adapter does not support system prompt (interactive)
+- **WHEN** executing an interactive step and the adapter does not support system prompts
+- **THEN** the runner wraps the full prompt content in `<system>` XML tags and passes it as the positional argument
+
+#### Scenario: Headless mode bypasses routing
+- **WHEN** executing a headless step regardless of adapter support
+- **THEN** the full prompt content is passed as the positional argument without wrapping (current behavior)
+
+#### Scenario: No enrichment
+- **WHEN** no engine enrichment is returned for a step
+- **THEN** the step prompt alone is subject to the same routing rules
+
+#### Scenario: No step prompt
+- **WHEN** a step has no prompt
+- **THEN** the runner skips the step (current behavior, unchanged)

--- a/openspec/changes/system-prompt/tasks.md
+++ b/openspec/changes/system-prompt/tasks.md
@@ -1,0 +1,1 @@
+- [ ] System prompt routing (`tasks/system-prompt-routing.md`)

--- a/openspec/changes/system-prompt/tasks/system-prompt-routing.md
+++ b/openspec/changes/system-prompt/tasks/system-prompt-routing.md
@@ -1,0 +1,36 @@
+# Task: System Prompt Routing
+
+## Goal
+
+Add system prompt support to the CLI adapter framework so that prompt content is delivered as a hidden system prompt in interactive mode (for adapters that support it) or wrapped in `<system>` XML tags (for adapters that don't), while keeping headless mode unchanged.
+
+## Background
+
+You MUST read these files before starting:
+- `openspec/changes/system-prompt/design.md` for the full design and approach
+- `openspec/changes/system-prompt/specs/system-prompt-delivery/spec.md` for routing behavior acceptance criteria
+- `openspec/changes/system-prompt/specs/cli-adapter/spec.md` for adapter interface and arg construction acceptance criteria
+- `openspec/changes/system-prompt/specs/engine-interface/spec.md` for enrichment separation acceptance criteria
+
+**Current state:** `buildAgentPrompt` in `internal/exec/agent.go` concatenates the step prompt and engine enrichment into a single string (`prompt = prompt + "\n\n" + enrichment`), which is passed as the positional CLI argument via `BuildArgsInput.Prompt`. In interactive mode, this appears as the first user message, cluttering the session.
+
+**What changes:**
+
+1. **Adapter interface** (`internal/cli/adapter.go`): Add `SupportsSystemPrompt() bool` to the `Adapter` interface. Add `SystemPrompt string` field to `BuildArgsInput`.
+
+2. **Claude adapter** (`internal/cli/claude.go`): `SupportsSystemPrompt()` returns `true`. `BuildArgs` emits `--append-system-prompt <content>` when `SystemPrompt` is non-empty.
+
+3. **Codex adapter** (`internal/cli/codex.go`): `SupportsSystemPrompt()` returns `false`. No other changes — it ignores the `SystemPrompt` field.
+
+4. **Routing logic** (`internal/exec/agent.go`): `buildAgentPrompt` stops concatenating — returns step prompt and enrichment as separate strings (signature stays `(prompt, enrichment string, err error)` but `prompt` no longer includes enrichment). At the `BuildArgsInput` construction site (~line 51), add inline routing:
+   - If headless → concatenate step prompt + enrichment into `Prompt` (current behavior)
+   - If interactive + adapter supports system prompt → set `SystemPrompt` to full content (step prompt + enrichment), leave `Prompt` empty
+   - If interactive + adapter doesn't support → wrap full content in `<system>` XML tags, set as `Prompt`
+
+**Constraints:**
+- The `emitAgentStart` call on the line after `BuildArgs` uses both `prompt` and `enrichment` for audit logging — make sure audit logging still receives the appropriate values.
+- Existing tests for `BuildArgs` in both adapters will need updated expectations for the new interface method and the system prompt flag behavior.
+
+## Done When
+
+All spec scenarios from the four spec files are covered by tests and passing. The `Adapter` interface compiles with the new method, both adapters implement it, and the routing logic correctly dispatches based on mode and adapter support.


### PR DESCRIPTION
## Summary

- Route enrichment content as a hidden system prompt in interactive mode for adapters that support it (Claude via `--append-system-prompt`), keeping the step prompt as a positional argument. For adapters without system prompt support (Codex), enrichment is wrapped in `<system>` XML tags and prepended to the positional prompt. Headless mode remains unchanged.
- Add `SupportsSystemPrompt()` to Adapter interface and `SystemPrompt` field to `BuildArgsInput`
- Only append positional prompt in `ClaudeAdapter.BuildArgs` when non-empty
- Include CWD in workflow-not-found error for better diagnostics
- Fix lint violations (hugeParam, ifElseChain) from validator run
- Include OpenSpec change artifacts (proposal, design, specs, tasks)

## Commits

- `feat: add system prompt routing for interactive mode` — core implementation with adapter interface changes
- `fix: address lint violations from validator run` — gocritic fixes
- `docs: add OpenSpec change artifacts for system prompt routing` — preserves design documents
- `fix: avoid empty positional prompt arg and improve workflow error diagnostics` — Qodo bug fix + error diagnostics
- `fix: route only enrichment to system prompt, keep step prompt positional` — CodeRabbit review fix + spec/proposal updates

## Test plan

- [ ] Verify interactive mode with Claude adapter uses `--append-system-prompt` for enrichment and positional arg for prompt
- [ ] Verify interactive mode without enrichment passes prompt positionally (no system prompt routing)
- [ ] Verify interactive mode with Codex adapter wraps enrichment in `<system>` XML tags prepended to prompt
- [ ] Verify headless mode behavior is unchanged
- [ ] Run linter to confirm no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native system-prompt delivery for Claude; adapters now declare system-prompt capability.
  * Interactive prompt routing adapts to adapter capabilities while preserving headless behavior.
  * Prompt and enrichment are separated so system prompts are delivered distinctly from user prompts.

* **Bug Fixes**
  * Improved "workflow not found" diagnostics to include the current working directory.

* **Documentation**
  * Added design/specs detailing system-prompt delivery and routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->