### PR TITLE
feat: add agent-initiated continue trigger via stdout sentinel

### DIFF
--- a/.validator/config.yml
+++ b/.validator/config.yml
@@ -1,17 +1,8 @@
-# Ordered list of CLI agents to try for reviews
 cli:
-  default_preference:
-    - codex
-    - claude
-  # Recommended settings (see docs/eval-results.md)
   adapters:
-    codex:
+    github-copilot:
       allow_tool_use: false
       thinking_budget: low
-    claude:
-      model: sonnet
-      allow_tool_use: false
-      thinking_budget: high
 
 # entry_points configured by /validator-setup
 entry_points:

--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -29,12 +29,16 @@ var version = "dev"
 // realProcessRunner implements exec.ProcessRunner using os/exec.
 type realProcessRunner struct{}
 
-func (r *realProcessRunner) RunShell(cmd string, captureStdout bool) (iexec.ProcessResult, error) {
+func (r *realProcessRunner) RunShell(cmd string, captureStdout bool, workdir string) (iexec.ProcessResult, error) {
 	c := exec.Command("sh", "-c", cmd) // #nosec G204 -- CLI runner executes user-defined shell commands by design
 	c.Stdin = os.Stdin
-	c.Stderr = os.Stderr
+	if workdir != "" {
+		c.Dir = filepath.Clean(workdir) // #nosec G304 -- workdir is from user-authored workflow YAML
+	}
 
 	if captureStdout {
+		var stderrBuf bytes.Buffer
+		c.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
 		out, err := c.Output()
 		exitCode := 0
 		if err != nil {
@@ -47,10 +51,12 @@ func (r *realProcessRunner) RunShell(cmd string, captureStdout bool) (iexec.Proc
 		return iexec.ProcessResult{
 			ExitCode: exitCode,
 			Stdout:   strings.TrimSpace(string(out)),
+			Stderr:   strings.TrimSpace(stderrBuf.String()),
 		}, nil
 	}
 
 	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
 	err := c.Run()
 	exitCode := 0
 	if err != nil {
@@ -63,14 +69,18 @@ func (r *realProcessRunner) RunShell(cmd string, captureStdout bool) (iexec.Proc
 	return iexec.ProcessResult{ExitCode: exitCode}, nil
 }
 
-func (r *realProcessRunner) RunAgent(args []string, captureStdout bool) (iexec.ProcessResult, error) {
+func (r *realProcessRunner) RunAgent(args []string, captureStdout bool, workdir string) (iexec.ProcessResult, error) {
 	c := exec.Command(args[0], args[1:]...) // #nosec G204 -- CLI runner launches agent processes by design
 	c.Stdin = os.Stdin
 	c.Stderr = os.Stderr
+	if workdir != "" {
+		c.Dir = filepath.Clean(workdir) // #nosec G304 -- workdir is from user-authored workflow YAML
+	}
 
 	if captureStdout {
-		var buf bytes.Buffer
-		c.Stdout = io.MultiWriter(os.Stdout, &buf)
+		var stdoutBuf, stderrBuf bytes.Buffer
+		c.Stdout = io.MultiWriter(os.Stdout, &stdoutBuf)
+		c.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
 		err := c.Run()
 		exitCode := 0
 		if err != nil {
@@ -80,10 +90,11 @@ func (r *realProcessRunner) RunAgent(args []string, captureStdout bool) (iexec.P
 				return iexec.ProcessResult{}, err
 			}
 		}
-		return iexec.ProcessResult{ExitCode: exitCode, Stdout: buf.String()}, nil
+		return iexec.ProcessResult{ExitCode: exitCode, Stdout: stdoutBuf.String(), Stderr: stderrBuf.String()}, nil
 	}
 
 	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
 	err := c.Run()
 	exitCode := 0
 	if err != nil {

--- a/internal/exec/agent.go
+++ b/internal/exec/agent.go
@@ -75,7 +75,7 @@ func ExecuteAgentStep(
 	logAgentStep(log, mode, prompt)
 
 	spawnTime := time.Now()
-	outcome, result, runErr := runAgentProcess(runner, args, headless, log)
+	outcome, result, runErr := runAgentProcess(runner, args, headless, step.Workdir, log)
 	if runErr != nil {
 		emitAgentEnd(ctx, prefix, startTime, "", OutcomeFailed)
 		return OutcomeFailed, runErr
@@ -129,15 +129,23 @@ func resolveAdapterAndSession(
 	return adapter, cliName, sessionID, isResume, nil
 }
 
-func runAgentProcess(runner ProcessRunner, args []string, headless bool, log Logger) (StepOutcome, ProcessResult, error) {
+func runAgentProcess(runner ProcessRunner, args []string, headless bool, workdir string, log Logger) (StepOutcome, ProcessResult, error) {
 	if headless {
 		// Capture stdout for headless runs so that adapters (e.g. Codex) can
 		// parse session IDs from the process output.
-		result, runErr := runner.RunAgent(args, true)
+		result, runErr := runner.RunAgent(args, true, workdir)
 		if runErr != nil {
 			return OutcomeFailed, result, runErr
 		}
 		if result.ExitCode != 0 {
+			return OutcomeFailed, result, nil
+		}
+		// Detect AskUserQuestion failures in headless mode — these indicate
+		// the agent could not complete the task autonomously. Use case-insensitive
+		// matching across both stdout and stderr to handle format variations.
+		combined := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+		if strings.Contains(combined, "askuserquestion") && strings.Contains(combined, "error") {
+			log.Errorf("  headless session attempted interactive prompt (AskUserQuestion); treating as failure\n")
 			return OutcomeFailed, result, nil
 		}
 		return OutcomeSuccess, result, nil

--- a/internal/exec/agent.go
+++ b/internal/exec/agent.go
@@ -63,13 +63,17 @@ func ExecuteAgentStep(
 	switch {
 	case headless:
 		input.Prompt = fullPrompt
-	case enrichment == "":
-		input.Prompt = prompt
 	case adapter.SupportsSystemPrompt():
-		input.Prompt = prompt
-		input.SystemPrompt = enrichment
+		input.SystemPrompt = fullPrompt
+		if isResume {
+			input.Prompt = "Let's continue"
+		} else {
+			input.Prompt = "Let's start"
+		}
+	case enrichment != "":
+		input.Prompt = "<system>\n" + fullPrompt + "\n</system>"
 	default:
-		input.Prompt = "<system>\n" + enrichment + "\n</system>\n\n" + prompt
+		input.Prompt = prompt
 	}
 
 	args := adapter.BuildArgs(&input)

--- a/internal/exec/agent.go
+++ b/internal/exec/agent.go
@@ -166,7 +166,7 @@ func runAgentProcess(runner ProcessRunner, args []string, headless bool, workdir
 	}
 
 	// Interactive: run inside a PTY with continue-trigger detection.
-	ptyResult, err := interactiveRunnerFn(args, pty.Options{})
+	ptyResult, err := interactiveRunnerFn(args, pty.Options{Workdir: workdir})
 	if err != nil {
 		return OutcomeFailed, ProcessResult{}, err
 	}
@@ -251,7 +251,7 @@ func logAgentStep(log Logger, mode model.StepMode, prompt string) {
 		log.Println("  (exit to stop)")
 	}
 	if mode == model.ModeHeadless && os.Getenv("AGENT_RUNNER_SHOW_PROMPT") == "1" {
-		for _, line := range strings.Split(prompt, "\n") {
+		for line := range strings.SplitSeq(prompt, "\n") {
 			log.Printf("  %s\n", line)
 		}
 	}

--- a/internal/exec/agent.go
+++ b/internal/exec/agent.go
@@ -20,6 +20,10 @@ import (
 // Defaults to pty.RunInteractive; replaced in tests.
 var interactiveRunnerFn = pty.RunInteractive
 
+// sentinelInstruction is appended to the prompt for interactive agent steps
+// so the agent knows how to signal task completion via the stdout sentinel.
+const sentinelInstruction = "\n\nWhen you have completed your task, signal completion by running this command in the terminal:\nprintf '\\x1b]999;red-slippers\\x07'"
+
 // ExecuteAgentStep runs an agent step using the resolved CLI adapter.
 func ExecuteAgentStep(
 	step *model.Step,
@@ -52,6 +56,9 @@ func ExecuteAgentStep(
 	if enrichment != "" {
 		fullPrompt = prompt + "\n\n" + enrichment
 	}
+	if !headless {
+		fullPrompt += sentinelInstruction
+	}
 
 	input := cli.BuildArgsInput{
 		SessionID: sessionID,
@@ -73,7 +80,7 @@ func ExecuteAgentStep(
 	case enrichment != "":
 		input.Prompt = "<system>\n" + fullPrompt + "\n</system>"
 	default:
-		input.Prompt = prompt
+		input.Prompt = fullPrompt
 	}
 
 	args := adapter.BuildArgs(&input)

--- a/internal/exec/agent_test.go
+++ b/internal/exec/agent_test.go
@@ -423,8 +423,12 @@ func TestExecuteAgentStep(t *testing.T) {
 		}
 		args := ptyCalls[0]
 		lastArg := args[len(args)-1]
-		if lastArg != "review code" {
+		if !strings.HasPrefix(lastArg, "review code") {
 			t.Fatalf("expected prompt as positional arg for codex without enrichment, got %q", lastArg)
+		}
+		// Interactive steps include the sentinel instruction appended to the prompt.
+		if !strings.Contains(lastArg, "red-slippers") {
+			t.Fatalf("expected sentinel instruction in codex interactive prompt, got %q", lastArg)
 		}
 	})
 
@@ -453,6 +457,49 @@ func TestExecuteAgentStep(t *testing.T) {
 		}
 		if strings.Contains(lastArg, "<system>") {
 			t.Fatalf("did not expect XML wrapping for headless mode, got %q", lastArg)
+		}
+	})
+
+	t.Run("interactive step prompt includes sentinel instruction", func(t *testing.T) {
+		var capturedArgs [][]string
+		oldFn := interactiveRunnerFn
+		interactiveRunnerFn = func(args []string, _ pty.Options) (pty.Result, error) {
+			capturedArgs = append(capturedArgs, args)
+			return pty.Result{ContinueTriggered: true}, nil
+		}
+		defer func() { interactiveRunnerFn = oldFn }()
+
+		runner := &mockRunner{}
+		step := model.Step{ID: "s", Mode: model.ModeInteractive, Prompt: "do the task", Session: model.SessionNew}
+		ExecuteAgentStep(&step, makeCtx(), runner, &mockLogger{})
+		if len(capturedArgs) == 0 {
+			t.Fatal("expected PTY to be called")
+		}
+		// For Claude interactive, the sentinel goes into --append-system-prompt.
+		// Find the value after --append-system-prompt.
+		args := capturedArgs[0]
+		for i, a := range args {
+			if a == "--append-system-prompt" && i+1 < len(args) {
+				if !strings.Contains(args[i+1], "red-slippers") {
+					t.Fatalf("expected sentinel instruction in system prompt, got %q", args[i+1])
+				}
+				return
+			}
+		}
+		t.Fatalf("expected --append-system-prompt with sentinel instruction, got %v", args)
+	})
+
+	t.Run("headless step prompt does not include sentinel instruction", func(t *testing.T) {
+		runner := &mockRunner{results: []ProcessResult{{ExitCode: 0}}}
+		step := model.Step{ID: "s", Mode: model.ModeHeadless, Prompt: "do the task", Session: model.SessionNew}
+		ExecuteAgentStep(&step, makeCtx(), runner, &mockLogger{})
+		if len(runner.calls) == 0 {
+			t.Fatal("expected command to be called")
+		}
+		// The last arg is the prompt for headless.
+		lastArg := runner.calls[0][len(runner.calls[0])-1]
+		if strings.Contains(lastArg, "red-slippers") {
+			t.Fatalf("expected no sentinel instruction in headless prompt, got %q", lastArg)
 		}
 	})
 }

--- a/internal/exec/agent_test.go
+++ b/internal/exec/agent_test.go
@@ -330,6 +330,42 @@ func TestExecuteAgentStep(t *testing.T) {
 		}
 	})
 
+	t.Run("headless fails when AskUserQuestion error detected in output", func(t *testing.T) {
+		runner := &mockRunner{results: []ProcessResult{{ExitCode: 0, Stdout: "Tool error: AskUserQuestion error: not supported in headless mode"}}}
+		step := model.Step{ID: "s", Mode: model.ModeHeadless, Prompt: "finalize", Session: model.SessionNew}
+		outcome, err := ExecuteAgentStep(&step, makeCtx(), runner, &mockLogger{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if outcome != OutcomeFailed {
+			t.Fatalf("expected failed for AskUserQuestion in headless, got %q", outcome)
+		}
+	})
+
+	t.Run("headless fails on case-variant AskUserQuestion error", func(t *testing.T) {
+		runner := &mockRunner{results: []ProcessResult{{ExitCode: 0, Stdout: "Error: askuserquestion not available"}}}
+		step := model.Step{ID: "s", Mode: model.ModeHeadless, Prompt: "finalize", Session: model.SessionNew}
+		outcome, err := ExecuteAgentStep(&step, makeCtx(), runner, &mockLogger{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if outcome != OutcomeFailed {
+			t.Fatalf("expected failed for case-insensitive AskUserQuestion detection, got %q", outcome)
+		}
+	})
+
+	t.Run("headless succeeds when output mentions AskUserQuestion without error", func(t *testing.T) {
+		runner := &mockRunner{results: []ProcessResult{{ExitCode: 0, Stdout: "I considered using AskUserQuestion but proceeded instead"}}}
+		step := model.Step{ID: "s", Mode: model.ModeHeadless, Prompt: "do it", Session: model.SessionNew}
+		outcome, err := ExecuteAgentStep(&step, makeCtx(), runner, &mockLogger{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if outcome != OutcomeSuccess {
+			t.Fatalf("expected success when AskUserQuestion mentioned without error, got %q", outcome)
+		}
+	})
+
 	t.Run("interactive does not call RunAgent on ProcessRunner", func(t *testing.T) {
 		oldFn := interactiveRunnerFn
 		interactiveRunnerFn = func(_ []string, _ pty.Options) (pty.Result, error) {

--- a/internal/exec/agent_test.go
+++ b/internal/exec/agent_test.go
@@ -381,7 +381,7 @@ func TestExecuteAgentStep(t *testing.T) {
 		}
 	})
 
-	t.Run("interactive claude without enrichment passes prompt positionally", func(t *testing.T) {
+	t.Run("interactive claude routes prompt to system prompt", func(t *testing.T) {
 		var ptyCalls [][]string
 		oldFn := interactiveRunnerFn
 		interactiveRunnerFn = func(args []string, _ pty.Options) (pty.Result, error) {
@@ -397,12 +397,12 @@ func TestExecuteAgentStep(t *testing.T) {
 			t.Fatal("expected PTY to be called")
 		}
 		args := ptyCalls[0]
-		lastArg := args[len(args)-1]
-		if lastArg != "review code" {
-			t.Fatalf("expected prompt as positional arg, got %q", lastArg)
+		if !containsArg(args, "--append-system-prompt") {
+			t.Fatal("expected --append-system-prompt for interactive claude step")
 		}
-		if containsArg(args, "--append-system-prompt") {
-			t.Fatal("did not expect --append-system-prompt without enrichment")
+		lastArg := args[len(args)-1]
+		if lastArg != "Let's start" {
+			t.Fatalf("expected 'Let's start' as positional arg, got %q", lastArg)
 		}
 	})
 

--- a/internal/exec/interfaces.go
+++ b/internal/exec/interfaces.go
@@ -20,8 +20,8 @@ type ProcessResult struct {
 
 // ProcessRunner abstracts process spawning for testability.
 type ProcessRunner interface {
-	RunShell(cmd string, captureStdout bool) (ProcessResult, error)
-	RunAgent(args []string, captureStdout bool) (ProcessResult, error)
+	RunShell(cmd string, captureStdout bool, workdir string) (ProcessResult, error)
+	RunAgent(args []string, captureStdout bool, workdir string) (ProcessResult, error)
 }
 
 // GlobExpander abstracts file globbing for testability.

--- a/internal/exec/shell.go
+++ b/internal/exec/shell.go
@@ -113,7 +113,7 @@ func ExecuteShellStep(
 	})
 
 	useCapture := step.Capture != ""
-	result, runErr := runner.RunShell(command, useCapture)
+	result, runErr := runner.RunShell(command, useCapture, step.Workdir)
 	if runErr != nil {
 		emitAudit(ctx, audit.Event{
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
@@ -129,7 +129,11 @@ func ExecuteShellStep(
 	}
 
 	if useCapture {
-		ctx.CapturedVariables[step.Capture] = result.Stdout
+		captured := result.Stdout
+		if step.CaptureStderr && result.ExitCode != 0 && result.Stderr != "" {
+			captured = captured + "\n\nSTDERR:\n" + result.Stderr
+		}
+		ctx.CapturedVariables[step.Capture] = captured
 	}
 
 	outcome := OutcomeSuccess

--- a/internal/exec/shell_test.go
+++ b/internal/exec/shell_test.go
@@ -16,7 +16,7 @@ type mockRunner struct {
 	idx     int
 }
 
-func (m *mockRunner) RunShell(cmd string, capture bool) (ProcessResult, error) {
+func (m *mockRunner) RunShell(cmd string, capture bool, _ string) (ProcessResult, error) {
 	m.calls = append(m.calls, []string{"sh", "-c", cmd})
 	if m.idx >= len(m.results) {
 		return ProcessResult{ExitCode: 0}, nil
@@ -26,7 +26,7 @@ func (m *mockRunner) RunShell(cmd string, capture bool) (ProcessResult, error) {
 	return r, nil
 }
 
-func (m *mockRunner) RunAgent(args []string, _ bool) (ProcessResult, error) {
+func (m *mockRunner) RunAgent(args []string, _ bool, _ string) (ProcessResult, error) {
 	m.calls = append(m.calls, args)
 	if m.idx >= len(m.results) {
 		return ProcessResult{ExitCode: 0}, nil
@@ -104,6 +104,41 @@ func TestExecuteShellStep(t *testing.T) {
 		ExecuteShellStep(&step, ctx, runner, &mockLogger{})
 		if ctx.CapturedVariables["output"] != "captured-output" {
 			t.Fatalf("expected captured output, got %q", ctx.CapturedVariables["output"])
+		}
+	})
+
+	t.Run("captures stdout and stderr on failure when capture_stderr enabled", func(t *testing.T) {
+		runner := &mockRunner{results: []ProcessResult{{ExitCode: 1, Stdout: "Status: error", Stderr: "config parse failed: bad format"}}}
+		ctx := makeCtx()
+		step := model.Step{ID: "s", Mode: model.ModeShell, Command: "validator run", Session: model.SessionNew, Capture: "output", CaptureStderr: true}
+		ExecuteShellStep(&step, ctx, runner, &mockLogger{})
+		captured := ctx.CapturedVariables["output"]
+		if !strings.Contains(captured, "Status: error") {
+			t.Fatalf("expected stdout in capture, got %q", captured)
+		}
+		if !strings.Contains(captured, "STDERR:") || !strings.Contains(captured, "config parse failed") {
+			t.Fatalf("expected stderr appended on failure, got %q", captured)
+		}
+	})
+
+	t.Run("does not append stderr on failure without capture_stderr", func(t *testing.T) {
+		runner := &mockRunner{results: []ProcessResult{{ExitCode: 1, Stdout: "Status: error", Stderr: "secret-token-abc123"}}}
+		ctx := makeCtx()
+		step := model.Step{ID: "s", Mode: model.ModeShell, Command: "validator run", Session: model.SessionNew, Capture: "output"}
+		ExecuteShellStep(&step, ctx, runner, &mockLogger{})
+		captured := ctx.CapturedVariables["output"]
+		if strings.Contains(captured, "secret-token") {
+			t.Fatalf("stderr should not be captured without capture_stderr, got %q", captured)
+		}
+	})
+
+	t.Run("does not append stderr on success even with capture_stderr", func(t *testing.T) {
+		runner := &mockRunner{results: []ProcessResult{{ExitCode: 0, Stdout: "ok", Stderr: "some warning"}}}
+		ctx := makeCtx()
+		step := model.Step{ID: "s", Mode: model.ModeShell, Command: "echo ok", Session: model.SessionNew, Capture: "output", CaptureStderr: true}
+		ExecuteShellStep(&step, ctx, runner, &mockLogger{})
+		if ctx.CapturedVariables["output"] != "ok" {
+			t.Fatalf("expected only stdout on success, got %q", ctx.CapturedVariables["output"])
 		}
 	})
 

--- a/internal/model/step.go
+++ b/internal/model/step.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -142,10 +143,8 @@ func validateCLIName(cliValue string, knownCLIs []string) error {
 	if knownCLIs == nil {
 		return nil
 	}
-	for _, name := range knownCLIs {
-		if name == cliValue {
-			return nil
-		}
+	if slices.Contains(knownCLIs, cliValue) {
+		return nil
 	}
 	return fmt.Errorf(`unknown cli adapter: %q`, cliValue)
 }
@@ -188,6 +187,17 @@ func (s *Step) validateFieldConstraints(knownCLIs []string) error {
 
 	if s.Capture != "" && s.Mode != ModeShell && s.Mode != ModeHeadless && s.Command == "" {
 		return fmt.Errorf(`"capture" is only allowed on shell and headless steps`)
+	}
+
+	if s.CaptureStderr && s.Capture == "" {
+		return fmt.Errorf(`"capture_stderr" requires "capture"`)
+	}
+	if s.CaptureStderr && s.Command == "" {
+		return fmt.Errorf(`"capture_stderr" is only allowed on shell steps`)
+	}
+
+	if s.Workdir != "" && s.Command == "" && !s.isAgentContext() {
+		return fmt.Errorf(`"workdir" is only allowed on shell and agent steps`)
 	}
 
 	isAgent := s.isAgentContext()

--- a/internal/model/step.go
+++ b/internal/model/step.go
@@ -67,10 +67,12 @@ type Step struct {
 	Session           SessionStrategy   `yaml:"session,omitempty" json:"session,omitempty"`
 	CLI               string            `yaml:"cli,omitempty" json:"cli,omitempty"`
 	Capture           string            `yaml:"capture,omitempty" json:"capture,omitempty"`
+	CaptureStderr     bool              `yaml:"capture_stderr,omitempty" json:"capture_stderr,omitempty"`
 	ContinueOnFailure bool              `yaml:"continue_on_failure,omitempty" json:"continue_on_failure,omitempty"`
 	SkipIf            string            `yaml:"skip_if,omitempty" json:"skip_if,omitempty"`
 	BreakIf           string            `yaml:"break_if,omitempty" json:"break_if,omitempty"`
 	Model             string            `yaml:"model,omitempty" json:"model,omitempty"`
+	Workdir           string            `yaml:"workdir,omitempty" json:"workdir,omitempty"`
 	Workflow          string            `yaml:"workflow,omitempty" json:"workflow,omitempty"`
 	Loop              *Loop             `yaml:"loop,omitempty" json:"loop,omitempty"`
 	Params            map[string]string `yaml:"params,omitempty" json:"params,omitempty"`

--- a/internal/pty/output.go
+++ b/internal/pty/output.go
@@ -1,6 +1,14 @@
 package pty
 
-const sentinelPayload = "999;red-slippers"
+const (
+	sentinelPayload = "999;red-slippers"
+
+	// maxEscBuf caps the escape/OSC buffer to prevent unbounded memory growth
+	// when the PTY stream contains an unterminated OSC sequence (e.g., a
+	// runaway agent that emits \x1b] and never sends BEL or ST). When the
+	// limit is exceeded the accumulated bytes are flushed as normal output.
+	maxEscBuf = 8 * 1024
+)
 
 // outOSCSawEsc is an additional parser state for outputProcessor only:
 // inside an OSC sequence (\x1b]...), a \x1b byte was seen — it may be the
@@ -84,6 +92,14 @@ func (p *outputProcessor) process(chunk []byte) outputResult {
 			default:
 				p.escBuf = append(p.escBuf, b)
 				p.oscPayload = append(p.oscPayload, b)
+				// Guard against unbounded memory growth from unterminated OSC
+				// sequences: flush accumulated bytes as normal output and reset.
+				if len(p.escBuf) > maxEscBuf {
+					fwd = append(fwd, p.escBuf...)
+					p.escBuf = p.escBuf[:0]
+					p.oscPayload = p.oscPayload[:0]
+					p.escState = escNone
+				}
 			}
 			continue
 

--- a/internal/pty/output.go
+++ b/internal/pty/output.go
@@ -88,7 +88,14 @@ func (p *outputProcessor) process(chunk []byte) outputResult {
 				}
 			case 0x1b: // potential start of ST (\x1b\)
 				p.escBuf = append(p.escBuf, b)
-				p.escState = outOSCSawEsc
+				if len(p.escBuf) > maxEscBuf {
+					fwd = append(fwd, p.escBuf...)
+					p.escBuf = p.escBuf[:0]
+					p.oscPayload = p.oscPayload[:0]
+					p.escState = escNone
+				} else {
+					p.escState = outOSCSawEsc
+				}
 			default:
 				p.escBuf = append(p.escBuf, b)
 				p.oscPayload = append(p.oscPayload, b)
@@ -115,6 +122,13 @@ func (p *outputProcessor) process(chunk []byte) outputResult {
 				// Not ST — treat the buffered \x1b and this byte as OSC payload.
 				p.oscPayload = append(p.oscPayload, 0x1b, b)
 				p.escState = escInStringSeq
+				// Centralized size guard: applies after any append to escBuf/oscPayload.
+				if len(p.escBuf) > maxEscBuf {
+					fwd = append(fwd, p.escBuf...)
+					p.escBuf = p.escBuf[:0]
+					p.oscPayload = p.oscPayload[:0]
+					p.escState = escNone
+				}
 			}
 			continue
 		}

--- a/internal/pty/output.go
+++ b/internal/pty/output.go
@@ -88,25 +88,14 @@ func (p *outputProcessor) process(chunk []byte) outputResult {
 				}
 			case 0x1b: // potential start of ST (\x1b\)
 				p.escBuf = append(p.escBuf, b)
-				if len(p.escBuf) > maxEscBuf {
-					fwd = append(fwd, p.escBuf...)
-					p.escBuf = p.escBuf[:0]
-					p.oscPayload = p.oscPayload[:0]
-					p.escState = escNone
-				} else {
+				fwd = p.flushIfOverflow(fwd)
+				if p.escState == escInStringSeq { // not flushed
 					p.escState = outOSCSawEsc
 				}
 			default:
 				p.escBuf = append(p.escBuf, b)
 				p.oscPayload = append(p.oscPayload, b)
-				// Guard against unbounded memory growth from unterminated OSC
-				// sequences: flush accumulated bytes as normal output and reset.
-				if len(p.escBuf) > maxEscBuf {
-					fwd = append(fwd, p.escBuf...)
-					p.escBuf = p.escBuf[:0]
-					p.oscPayload = p.oscPayload[:0]
-					p.escState = escNone
-				}
+				fwd = p.flushIfOverflow(fwd)
 			}
 			continue
 
@@ -122,13 +111,7 @@ func (p *outputProcessor) process(chunk []byte) outputResult {
 				// Not ST — treat the buffered \x1b and this byte as OSC payload.
 				p.oscPayload = append(p.oscPayload, 0x1b, b)
 				p.escState = escInStringSeq
-				// Centralized size guard: applies after any append to escBuf/oscPayload.
-				if len(p.escBuf) > maxEscBuf {
-					fwd = append(fwd, p.escBuf...)
-					p.escBuf = p.escBuf[:0]
-					p.oscPayload = p.oscPayload[:0]
-					p.escState = escNone
-				}
+				fwd = p.flushIfOverflow(fwd)
 			}
 			continue
 		}
@@ -143,6 +126,20 @@ func (p *outputProcessor) process(chunk []byte) outputResult {
 	}
 
 	return outputResult{forward: fwd, triggered: triggered}
+}
+
+// flushIfOverflow checks whether escBuf exceeds maxEscBuf. If so, it appends
+// the buffered bytes to fwd, resets the parser, and returns the updated slice.
+// This centralises the overflow guard so the main process loop stays compact.
+func (p *outputProcessor) flushIfOverflow(fwd []byte) []byte {
+	if len(p.escBuf) <= maxEscBuf {
+		return fwd
+	}
+	fwd = append(fwd, p.escBuf...)
+	p.escBuf = p.escBuf[:0]
+	p.oscPayload = p.oscPayload[:0]
+	p.escState = escNone
+	return fwd
 }
 
 // flush returns any bytes buffered in a partial escape sequence as normal

--- a/internal/pty/output.go
+++ b/internal/pty/output.go
@@ -1,0 +1,129 @@
+package pty
+
+const sentinelPayload = "999;red-slippers"
+
+// outOSCSawEsc is an additional parser state for outputProcessor only:
+// inside an OSC sequence (\x1b]...), a \x1b byte was seen — it may be the
+// start of a string terminator (ST = \x1b\).
+const outOSCSawEsc = 10
+
+// outputProcessor tracks ANSI escape sequence state and detects the sentinel
+// OSC sequence \x1b]999;red-slippers\x07 in the output stream.
+//
+// The sentinel is stripped from output (never forwarded to the terminal).
+// All other bytes, including non-matching OSC sequences, are forwarded as-is.
+// State persists across process() calls so sentinels split across PTY read
+// chunk boundaries are detected correctly.
+type outputProcessor struct {
+	escState   int
+	escBuf     []byte // bytes accumulated for the current escape sequence
+	oscPayload []byte // OSC payload bytes (between \x1b] and BEL/ST)
+}
+
+// outputResult holds the outcome of processing an output chunk.
+type outputResult struct {
+	forward   []byte // bytes to write to os.Stdout
+	triggered bool   // true if the sentinel was detected
+}
+
+// process processes a chunk of output bytes, detecting and stripping the
+// sentinel OSC sequence. Returns the bytes to forward and whether the sentinel
+// was detected. Processing continues after sentinel detection so that bytes
+// surrounding the sentinel in the same chunk are forwarded normally.
+func (p *outputProcessor) process(chunk []byte) outputResult {
+	var fwd []byte
+	triggered := false
+
+	for _, b := range chunk {
+		switch p.escState {
+		case escSawEsc:
+			p.escBuf = append(p.escBuf, b)
+			switch b {
+			case ']':
+				p.escState = escInStringSeq
+				p.oscPayload = p.oscPayload[:0]
+			case '[':
+				p.escState = escInCSI
+			default:
+				// Simple two-byte escape or unrecognised — flush and reset.
+				fwd = append(fwd, p.escBuf...)
+				p.escBuf = p.escBuf[:0]
+				p.escState = escNone
+			}
+			continue
+
+		case escInCSI:
+			p.escBuf = append(p.escBuf, b)
+			if b >= 0x40 && b <= 0x7e { // final byte
+				fwd = append(fwd, p.escBuf...)
+				p.escBuf = p.escBuf[:0]
+				p.escState = escNone
+			}
+			continue
+
+		case escInStringSeq:
+			switch b {
+			case 0x07: // BEL terminates OSC
+				if string(p.oscPayload) == sentinelPayload {
+					// Sentinel matched — strip (don't forward), signal trigger.
+					p.escBuf = p.escBuf[:0]
+					p.oscPayload = p.oscPayload[:0]
+					p.escState = escNone
+					triggered = true
+				} else {
+					// Non-matching OSC — flush the buffered bytes.
+					p.escBuf = append(p.escBuf, b)
+					fwd = append(fwd, p.escBuf...)
+					p.escBuf = p.escBuf[:0]
+					p.oscPayload = p.oscPayload[:0]
+					p.escState = escNone
+				}
+			case 0x1b: // potential start of ST (\x1b\)
+				p.escBuf = append(p.escBuf, b)
+				p.escState = outOSCSawEsc
+			default:
+				p.escBuf = append(p.escBuf, b)
+				p.oscPayload = append(p.oscPayload, b)
+			}
+			continue
+
+		case outOSCSawEsc:
+			p.escBuf = append(p.escBuf, b)
+			if b == '\\' {
+				// ST terminator — flush (our sentinel uses BEL, not ST).
+				fwd = append(fwd, p.escBuf...)
+				p.escBuf = p.escBuf[:0]
+				p.oscPayload = p.oscPayload[:0]
+				p.escState = escNone
+			} else {
+				// Not ST — treat the buffered \x1b and this byte as OSC payload.
+				p.oscPayload = append(p.oscPayload, 0x1b, b)
+				p.escState = escInStringSeq
+			}
+			continue
+		}
+
+		// escNone: normal byte.
+		if b == 0x1b {
+			p.escBuf = append(p.escBuf[:0], b)
+			p.escState = escSawEsc
+		} else {
+			fwd = append(fwd, b)
+		}
+	}
+
+	return outputResult{forward: fwd, triggered: triggered}
+}
+
+// flush returns any bytes buffered in a partial escape sequence as normal
+// output. Call this when the process exits to avoid dropping partial sequences.
+func (p *outputProcessor) flush() []byte {
+	if len(p.escBuf) == 0 {
+		return nil
+	}
+	out := append([]byte(nil), p.escBuf...)
+	p.escBuf = p.escBuf[:0]
+	p.oscPayload = p.oscPayload[:0]
+	p.escState = escNone
+	return out
+}

--- a/internal/pty/output_test.go
+++ b/internal/pty/output_test.go
@@ -1,0 +1,179 @@
+package pty
+
+import "testing"
+
+const sentinel = "\x1b]999;red-slippers\x07"
+
+func TestOutputProcessor(t *testing.T) {
+	t.Run("forwards regular text", func(t *testing.T) {
+		p := &outputProcessor{}
+		r := p.process([]byte("hello world"))
+		if r.triggered {
+			t.Fatal("unexpected trigger")
+		}
+		if string(r.forward) != "hello world" {
+			t.Fatalf("expected %q, got %q", "hello world", string(r.forward))
+		}
+	})
+
+	t.Run("detects sentinel and strips it", func(t *testing.T) {
+		p := &outputProcessor{}
+		r := p.process([]byte(sentinel))
+		if !r.triggered {
+			t.Fatal("expected trigger")
+		}
+		if len(r.forward) != 0 {
+			t.Fatalf("expected no forwarded bytes, got %q", string(r.forward))
+		}
+	})
+
+	t.Run("sentinel embedded in other output", func(t *testing.T) {
+		p := &outputProcessor{}
+		input := "before" + sentinel + "after"
+		r := p.process([]byte(input))
+		if !r.triggered {
+			t.Fatal("expected trigger")
+		}
+		// Bytes before AND after the sentinel are forwarded.
+		if string(r.forward) != "beforeafter" {
+			t.Fatalf("expected %q, got %q", "beforeafter", string(r.forward))
+		}
+	})
+
+	t.Run("sentinel detection across chunk boundaries", func(t *testing.T) {
+		p := &outputProcessor{}
+		// Split the sentinel in the middle of the payload.
+		half := len(sentinel) / 2
+		r1 := p.process([]byte(sentinel[:half]))
+		if r1.triggered {
+			t.Fatal("unexpected trigger on first half")
+		}
+		if len(r1.forward) != 0 {
+			t.Fatalf("expected no forwarded bytes on first half, got %q", string(r1.forward))
+		}
+		r2 := p.process([]byte(sentinel[half:]))
+		if !r2.triggered {
+			t.Fatal("expected trigger after second half")
+		}
+		if len(r2.forward) != 0 {
+			t.Fatalf("expected no forwarded bytes on second half, got %q", string(r2.forward))
+		}
+	})
+
+	t.Run("sentinel split byte by byte across chunks", func(t *testing.T) {
+		p := &outputProcessor{}
+		for i := 0; i < len(sentinel)-1; i++ {
+			r := p.process([]byte{sentinel[i]})
+			if r.triggered {
+				t.Fatalf("unexpected trigger at byte %d", i)
+			}
+		}
+		r := p.process([]byte{sentinel[len(sentinel)-1]})
+		if !r.triggered {
+			t.Fatal("expected trigger after final byte")
+		}
+	})
+
+	t.Run("incomplete sentinel at process exit is flushed", func(t *testing.T) {
+		p := &outputProcessor{}
+		// Write the start of the sentinel but don't complete it.
+		partial := sentinel[:10]
+		r := p.process([]byte(partial))
+		if r.triggered {
+			t.Fatal("unexpected trigger on partial sentinel")
+		}
+		if len(r.forward) != 0 {
+			t.Fatalf("expected no forwarded bytes (buffered), got %q", string(r.forward))
+		}
+		// flush() returns the buffered partial bytes.
+		flushed := p.flush()
+		if string(flushed) != partial {
+			t.Fatalf("expected flushed %q, got %q", partial, string(flushed))
+		}
+	})
+
+	t.Run("non-matching OSC sequence passed through", func(t *testing.T) {
+		p := &outputProcessor{}
+		osc := "\x1b]0;window title\x07"
+		r := p.process([]byte(osc))
+		if r.triggered {
+			t.Fatal("unexpected trigger on non-matching OSC")
+		}
+		if string(r.forward) != osc {
+			t.Fatalf("expected %q forwarded, got %q", osc, string(r.forward))
+		}
+	})
+
+	t.Run("non-matching OSC sequence surrounded by text passed through", func(t *testing.T) {
+		p := &outputProcessor{}
+		osc := "\x1b]0;title\x07"
+		input := "pre" + osc + "post"
+		r := p.process([]byte(input))
+		if r.triggered {
+			t.Fatal("unexpected trigger")
+		}
+		if string(r.forward) != input {
+			t.Fatalf("expected %q forwarded, got %q", input, string(r.forward))
+		}
+	})
+
+	t.Run("CSI sequence passed through", func(t *testing.T) {
+		p := &outputProcessor{}
+		csi := "\x1b[32mgreen\x1b[0m"
+		r := p.process([]byte(csi))
+		if r.triggered {
+			t.Fatal("unexpected trigger inside CSI")
+		}
+		if string(r.forward) != csi {
+			t.Fatalf("expected %q forwarded, got %q", csi, string(r.forward))
+		}
+	})
+
+	t.Run("escape state persists across chunks", func(t *testing.T) {
+		p := &outputProcessor{}
+		// Send just the ESC byte in one chunk.
+		r1 := p.process([]byte{0x1b})
+		if r1.triggered {
+			t.Fatal("unexpected trigger on bare ESC")
+		}
+		if len(r1.forward) != 0 {
+			t.Fatalf("expected ESC buffered, got %q", string(r1.forward))
+		}
+		// Complete a CSI sequence in the next chunk.
+		r2 := p.process([]byte("[2J"))
+		if r2.triggered {
+			t.Fatal("unexpected trigger inside split CSI")
+		}
+		if string(r2.forward) != "\x1b[2J" {
+			t.Fatalf("expected %q, got %q", "\x1b[2J", string(r2.forward))
+		}
+	})
+
+	t.Run("flush on empty buffer returns nil", func(t *testing.T) {
+		p := &outputProcessor{}
+		if p.flush() != nil {
+			t.Fatal("expected nil flush on empty buffer")
+		}
+	})
+
+	t.Run("flush after normal output returns nil", func(t *testing.T) {
+		p := &outputProcessor{}
+		p.process([]byte("hello"))
+		if p.flush() != nil {
+			t.Fatal("expected nil flush after complete output")
+		}
+	})
+
+	t.Run("OSC terminated by ST passed through", func(t *testing.T) {
+		p := &outputProcessor{}
+		// OSC terminated by ST (\x1b\) rather than BEL.
+		osc := "\x1b]0;title\x1b\\"
+		r := p.process([]byte(osc))
+		if r.triggered {
+			t.Fatal("unexpected trigger on ST-terminated OSC")
+		}
+		if string(r.forward) != osc {
+			t.Fatalf("expected %q forwarded, got %q", osc, string(r.forward))
+		}
+	})
+}

--- a/internal/pty/pty.go
+++ b/internal/pty/pty.go
@@ -107,7 +107,7 @@ func RunInteractive(args []string, opts Options) (Result, error) {
 	outputDone := make(chan struct{})
 	go func() {
 		defer close(outputDone)
-		forwardOutput(ptmx, hint)
+		forwardOutput(ptmx, hint, cmd, state, exitCh)
 	}()
 
 	// Read stdin, process input, forward to PTY, detect continue triggers.
@@ -172,17 +172,42 @@ func startResizeHandler(ptmx *os.File) chan os.Signal {
 }
 
 // forwardOutput reads from the PTY master and writes to stdout, managing the
-// idle hint timer. Returns when the PTY master is closed or errors.
-func forwardOutput(ptmx *os.File, hint *idleHint) {
+// idle hint timer. It detects the sentinel OSC sequence in the output stream;
+// on detection, the sentinel is stripped and the continue + termination
+// protocol is triggered (SIGTERM then SIGKILL after killTimeout), mirroring
+// the logic in processStdin. Returns when the PTY master is closed or errors.
+func forwardOutput(ptmx *os.File, hint *idleHint, cmd *exec.Cmd, state *ptyState, exitCh chan struct{}) {
+	proc := &outputProcessor{}
 	buf := make([]byte, 4096)
 	for {
 		n, err := ptmx.Read(buf)
 		if n > 0 {
+			result := proc.process(buf[:n])
 			hint.clearIfShown()
-			_, _ = os.Stdout.Write(buf[:n])
+			if len(result.forward) > 0 {
+				_, _ = os.Stdout.Write(result.forward)
+			}
 			hint.reset()
+			if result.triggered {
+				if !state.tryTriggerContinue() {
+					return
+				}
+				hint.cancel()
+				_ = cmd.Process.Signal(syscall.SIGTERM)
+				go func() {
+					select {
+					case <-time.After(killTimeout):
+						_ = cmd.Process.Kill()
+					case <-exitCh:
+					}
+				}()
+				return
+			}
 		}
 		if err != nil {
+			if flushed := proc.flush(); len(flushed) > 0 {
+				_, _ = os.Stdout.Write(flushed)
+			}
 			hint.cancel()
 			return
 		}

--- a/internal/pty/pty.go
+++ b/internal/pty/pty.go
@@ -29,7 +29,8 @@ type Result struct {
 
 // Options configures the interactive PTY session.
 type Options struct {
-	Env []string // additional environment variables
+	Env     []string // additional environment variables
+	Workdir string   // working directory for the child process
 }
 
 // ptyState holds shared mutable state for a PTY session.
@@ -89,6 +90,9 @@ func RunInteractive(args []string, opts Options) (Result, error) {
 	// Build and start the command inside a PTY.
 	cmd := exec.Command(args[0], args[1:]...) // #nosec G204 -- interactive agent execution by design
 	cmd.Env = buildEnv(opts.Env)
+	if opts.Workdir != "" {
+		cmd.Dir = opts.Workdir
+	}
 
 	ptmx, err := startWithTermSize(cmd)
 	if err != nil {
@@ -171,49 +175,96 @@ func startResizeHandler(ptmx *os.File) chan os.Signal {
 	return ch
 }
 
+// writeStdout writes data to stdout, returning any write error.
+func writeStdout(data []byte) error {
+	_, err := os.Stdout.Write(data)
+	return err
+}
+
+// beginTermination triggers the continue protocol and schedules SIGTERM/SIGKILL.
+// Returns false if the continue trigger was already consumed elsewhere.
+func beginTermination(cmd *exec.Cmd, state *ptyState, hint *idleHint, exitCh chan struct{}) bool {
+	if !state.tryTriggerContinue() {
+		return false
+	}
+	hint.cancel()
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	go func() {
+		select {
+		case <-time.After(killTimeout):
+			_ = cmd.Process.Kill()
+		case <-exitCh:
+		}
+	}()
+	return true
+}
+
 // forwardOutput reads from the PTY master and writes to stdout, managing the
 // idle hint timer. It detects the sentinel OSC sequence in the output stream;
 // on detection, the sentinel is stripped and the continue + termination
 // protocol is triggered (SIGTERM then SIGKILL after killTimeout), mirroring
 // the logic in processStdin. Returns when the PTY master is closed or errors.
+// flushToStdout drains any buffered bytes from the output processor to stdout,
+// returning any write error so callers can handle it.
+func flushToStdout(proc *outputProcessor) error {
+	flushed := proc.flush()
+	if len(flushed) == 0 {
+		return nil
+	}
+	return writeStdout(flushed)
+}
+
+// forwardChunk processes a single chunk of PTY output, forwarding clean bytes
+// to stdout and detecting the sentinel trigger. Returns true if the sentinel
+// was triggered in this chunk (transitioning sentinelTriggered from false to true).
+// Returns false with a non-nil error if a write to stdout fails.
+func forwardChunk(result outputResult, proc *outputProcessor, hint *idleHint, sentinelTriggered bool) (triggered bool, err error) {
+	if !sentinelTriggered {
+		hint.clearIfShown()
+		if len(result.forward) > 0 {
+			if werr := writeStdout(result.forward); werr != nil {
+				return false, werr
+			}
+		}
+		hint.reset()
+	}
+	if result.triggered && !sentinelTriggered {
+		if ferr := flushToStdout(proc); ferr != nil {
+			return false, ferr
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
 func forwardOutput(ptmx *os.File, hint *idleHint, cmd *exec.Cmd, state *ptyState, exitCh chan struct{}) {
 	proc := &outputProcessor{}
 	buf := make([]byte, 4096)
+	sentinelTriggered := false
 	for {
 		n, err := ptmx.Read(buf)
 		if n > 0 {
 			result := proc.process(buf[:n])
-			hint.clearIfShown()
-			if len(result.forward) > 0 {
-				_, _ = os.Stdout.Write(result.forward)
+			triggered, werr := forwardChunk(result, proc, hint, sentinelTriggered)
+			if werr != nil {
+				hint.cancel()
+				return
 			}
-			hint.reset()
-			if result.triggered {
-				// Flush any bytes buffered in a partial escape sequence that
-				// followed the sentinel in the same PTY read chunk.
-				if flushed := proc.flush(); len(flushed) > 0 {
-					_, _ = os.Stdout.Write(flushed)
-				}
-				if !state.tryTriggerContinue() {
+			if triggered {
+				sentinelTriggered = true
+				if !beginTermination(cmd, state, hint, exitCh) {
 					return
 				}
-				hint.cancel()
-				_ = cmd.Process.Signal(syscall.SIGTERM)
-				go func() {
-					select {
-					case <-time.After(killTimeout):
-						_ = cmd.Process.Kill()
-					case <-exitCh:
-					}
-				}()
-				return
 			}
 		}
 		if err != nil {
-			if flushed := proc.flush(); len(flushed) > 0 {
-				_, _ = os.Stdout.Write(flushed)
+			if !sentinelTriggered {
+				if ferr := flushToStdout(proc); ferr != nil {
+					hint.cancel()
+					return
+				}
+				hint.cancel()
 			}
-			hint.cancel()
 			return
 		}
 	}

--- a/internal/pty/pty.go
+++ b/internal/pty/pty.go
@@ -189,6 +189,11 @@ func forwardOutput(ptmx *os.File, hint *idleHint, cmd *exec.Cmd, state *ptyState
 			}
 			hint.reset()
 			if result.triggered {
+				// Flush any bytes buffered in a partial escape sequence that
+				// followed the sentinel in the same PTY read chunk.
+				if flushed := proc.flush(); len(flushed) > 0 {
+					_, _ = os.Stdout.Write(flushed)
+				}
 				if !state.tryTriggerContinue() {
 					return
 				}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -16,7 +16,7 @@ type mockRunner struct {
 	idx     int
 }
 
-func (m *mockRunner) RunShell(cmd string, capture bool) (exec.ProcessResult, error) {
+func (m *mockRunner) RunShell(cmd string, capture bool, _ string) (exec.ProcessResult, error) {
 	m.calls = append(m.calls, []string{"sh", "-c", cmd})
 	if m.idx >= len(m.results) {
 		return exec.ProcessResult{ExitCode: 0}, nil
@@ -26,7 +26,7 @@ func (m *mockRunner) RunShell(cmd string, capture bool) (exec.ProcessResult, err
 	return r, nil
 }
 
-func (m *mockRunner) RunAgent(args []string, _ bool) (exec.ProcessResult, error) {
+func (m *mockRunner) RunAgent(args []string, _ bool, _ string) (exec.ProcessResult, error) {
 	m.calls = append(m.calls, args)
 	if m.idx >= len(m.results) {
 		return exec.ProcessResult{ExitCode: 0}, nil

--- a/openspec/changes/allow-agent-to-exit/.openspec.yaml
+++ b/openspec/changes/allow-agent-to-exit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/allow-agent-to-exit/design.md
+++ b/openspec/changes/allow-agent-to-exit/design.md
@@ -1,0 +1,96 @@
+## Context
+
+Interactive agent steps can only advance to the next workflow step via user-initiated triggers (`/next` or Ctrl-]). The agent has no mechanism to signal "I'm done" — it sits idle until the user manually advances. This blocks autonomous multi-step workflows.
+
+The PTY layer (`internal/pty/`) already has the infrastructure for continue triggers: `tryTriggerContinue` for atomic state transitions, SIGTERM/SIGKILL cascade for graceful termination, and a byte-by-byte input processor that detects triggers in stdin. This design adds a parallel detection path in the output stream.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow agents to signal task completion by emitting a sentinel sequence in stdout
+- Trigger the existing continue and termination protocol when the sentinel is detected
+- Strip the sentinel from terminal output so users never see it
+- Automatically inject sentinel instructions into interactive step prompts
+
+**Non-Goals:**
+- Changing the headless execution path (headless steps already run to completion)
+- Bidirectional communication between runner and agent beyond the continue signal
+- Allowing the agent to pass data or status codes through the sentinel
+- Modifying workflow YAML schema
+
+## Approach
+
+```
+Agent stdout → PTY master → forwardOutput → outputProcessor.process(chunk)
+                                              │
+                                  ┌───────────┴───────────┐
+                                  │                       │
+                            Normal bytes            Sentinel detected
+                                  │                       │
+                            Forward to              Strip from output
+                            os.Stdout               tryTriggerContinue()
+                                                    SIGTERM → SIGKILL
+```
+
+### Sentinel format
+
+OSC private-use escape sequence: `\x1b]999;red-slippers\x07` (21 bytes).
+
+Terminals silently ignore unknown OSC sequences, so the sentinel is harmless if leaked. The `999` prefix is in the private-use range (not assigned by any standard). The payload `red-slippers` is unique enough to avoid collisions with any real terminal protocol.
+
+### Output processor (`internal/pty/output.go`)
+
+New file containing `outputProcessor` — a byte-by-byte state machine mirroring the existing `inputProcessor` in `input.go`.
+
+Tracks escape sequence state (ESC, OSC). When inside an OSC sequence, accumulates the payload into a buffer. On BEL termination:
+- If payload matches `999;red-slippers`: strip the sentinel bytes, return `triggered=true`
+- If payload does not match: flush the accumulated OSC bytes to the output as normal terminal data
+
+State persists across `process()` calls, so a sentinel split across PTY read chunk boundaries is detected correctly.
+
+Returns an `outputResult` with:
+- `forward []byte` — bytes to write to `os.Stdout`
+- `triggered bool` — whether the sentinel was detected
+
+### forwardOutput changes (`internal/pty/pty.go`)
+
+Signature expands to accept `cmd *exec.Cmd`, `state *ptyState`, and `exitCh chan struct{}` (same parameters as `processStdin`).
+
+The read loop feeds each chunk through `outputProcessor.process()`. Normal output is forwarded to `os.Stdout`. On trigger, the function runs the SIGTERM + SIGKILL timeout logic (inlined, mirroring `processStdin`):
+
+1. Call `state.tryTriggerContinue()` — if it returns false (process already exited), return
+2. Cancel the idle hint
+3. Send SIGTERM to the child process
+4. Spawn a goroutine that sends SIGKILL after `killTimeout` unless `exitCh` closes first
+
+### Prompt injection (`internal/exec/agent.go`)
+
+In `ExecuteAgentStep`, after building the prompt and enrichment, append the sentinel instruction for interactive steps:
+
+```
+When you have completed your task, signal completion by running this command in the terminal:
+printf '\x1b]999;red-slippers\x07'
+```
+
+This is appended unconditionally for all interactive steps. The agent always knows how to signal completion. Users can still use `/next` or Ctrl-] — the sentinel is additive.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Sentinel format | OSC `\x1b]999;red-slippers\x07` | Private-use range, terminals ignore unknown OSC, cannot collide with normal output |
+| Output processor architecture | Byte-by-byte state machine | Mirrors existing `inputProcessor` pattern, handles chunk splits naturally via persistent state, structurally aware of escape sequences |
+| Agent instruction delivery | Runner auto-injects into prompt | Zero workflow-author effort, consistent behavior across all interactive steps |
+| Trigger wiring | Pass state/cmd/exitCh as parameters to forwardOutput | Same pattern as `processStdin`, straightforward |
+| Trigger logic sharing | Inline in both processStdin and forwardOutput | Two call sites does not justify extraction; revisit if a third appears |
+
+## Risks / Trade-offs
+
+- **[Agent ignores instruction]** → The agent might not emit the sentinel. Mitigation: user can still `/next` manually — this is additive, not replacing existing triggers.
+- **[Duplicated SIGTERM/SIGKILL logic]** → Both `processStdin` and `forwardOutput` have the same ~8 lines of trigger code. Acceptable duplication for two call sites; extract to a shared helper if a third caller appears.
+- **[Prompt bloat]** → Every interactive step gets the sentinel instruction appended (~2 sentences). Negligible token cost.
+- **[Sentinel in agent reasoning output]** → The agent could theoretically print the sentinel while explaining what it does rather than executing it. Mitigation: the OSC escape uses non-printable bytes that won't appear in explanatory text — only in a deliberate `printf`.
+
+## Open Questions
+
+None — all architectural decisions are resolved.

--- a/openspec/changes/allow-agent-to-exit/proposal.md
+++ b/openspec/changes/allow-agent-to-exit/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+In interactive mode, only the user can trigger step transitions (via `/next` or Ctrl-]). An agent that finishes its work has no way to signal "I'm done" — it sits idle until the user notices and manually advances. This blocks autonomous multi-step workflows where the agent should be able to complete a step and move on without human intervention.
+
+## What Changes
+
+- Add agent-initiated continue trigger: the PTY output path detects a sentinel sequence emitted by the agent's stdout and triggers the same continue logic as `/next`
+- Introduce an output processor that scans PTY output for the sentinel, strips it before forwarding to the terminal, and fires `tryTriggerContinue()`
+- The sentinel uses an OSC private-use escape sequence (`\x1b]999;red-slippers\x07`) so it cannot collide with normal terminal output and is harmless if leaked
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-continue-trigger`: Agent-initiated continue trigger via stdout sentinel detection. Covers sentinel format, output scanning, stripping from display, and integration with the existing continue/termination flow.
+
+### Modified Capabilities
+
+- `pseudo-terminal`: The PTY spec's continue trigger requirements expand to include agent-originated triggers in addition to user-originated triggers. The graceful termination and escape sequence handling requirements also apply to the new trigger source.
+
+## Out of Scope
+
+- Changing the headless execution path — headless steps already run to completion naturally
+- Adding bidirectional communication channels between runner and agent beyond the sentinel
+- Allowing the agent to pass data (e.g., variables, status codes) through the sentinel — this is a simple "continue" signal only
+- Modifications to workflow step definitions or YAML schema
+
+## Impact
+
+- **`internal/pty/pty.go`**: `forwardOutput` gains access to state, cmd, and exitCh; calls new output processor instead of writing directly to stdout
+- **`internal/pty/` (new file)**: Output processor analogous to `input.go` — buffers output to detect sentinel across chunk boundaries, strips sentinel bytes, forwards clean output
+- **`internal/pty/pty.go`**: `RunInteractive` wires the output processor into the PTY goroutines
+- **`internal/exec/agent.go`**: The runner automatically appends sentinel instructions to interactive step prompts — zero workflow-author effort
+- **Existing behavior preserved**: User-initiated `/next` and Ctrl-] continue to work unchanged

--- a/openspec/changes/allow-agent-to-exit/specs/agent-continue-trigger/spec.md
+++ b/openspec/changes/allow-agent-to-exit/specs/agent-continue-trigger/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Agent-initiated continue via stdout sentinel
+
+The PTY layer SHALL detect a designated sentinel escape sequence in the agent's stdout output. When detected, the sentinel SHALL be stripped from the output (never forwarded to the terminal) and the runner SHALL trigger the existing continue and termination protocol, advancing to the next workflow step with outcome success — identical to a user-initiated `/next`.
+
+#### Scenario: Agent emits sentinel
+- **WHEN** the agent writes the sentinel sequence to stdout during an interactive step
+- **THEN** the runner triggers continue and advances to the next step with outcome success
+
+#### Scenario: Sentinel stripped from output
+- **WHEN** the agent writes the sentinel sequence to stdout
+- **THEN** the sentinel bytes are not displayed on the user's terminal
+
+#### Scenario: Sentinel embedded in other output
+- **WHEN** the agent writes the sentinel surrounded by other output bytes in the same write
+- **THEN** only the sentinel is stripped; surrounding output is forwarded to the terminal normally
+
+#### Scenario: Sentinel detection across chunk boundaries
+- **WHEN** the sentinel sequence arrives split across PTY read chunks
+- **THEN** the output processor detects and strips the sentinel
+
+#### Scenario: Incomplete sentinel at process exit
+- **WHEN** the agent writes a partial sentinel sequence and the process exits before the sequence is completed
+- **THEN** the buffered partial bytes are flushed to the terminal as normal output
+
+#### Scenario: Non-matching OSC sequence passed through
+- **WHEN** the agent writes an OSC sequence that does not match the sentinel payload
+- **THEN** the entire OSC sequence is forwarded to the terminal as normal output
+
+### Requirement: Sentinel instruction injection
+
+The runner SHALL automatically append sentinel completion instructions to the prompt for all interactive agent steps. Headless steps SHALL NOT receive the instruction.
+
+#### Scenario: Interactive step receives sentinel instruction
+- **WHEN** the runner builds the prompt for an interactive agent step
+- **THEN** the prompt includes an instruction telling the agent how to emit the sentinel
+
+#### Scenario: Headless step does not receive sentinel instruction
+- **WHEN** the runner builds the prompt for a headless agent step
+- **THEN** the prompt does not include the sentinel instruction

--- a/openspec/changes/allow-agent-to-exit/specs/pseudo-terminal/spec.md
+++ b/openspec/changes/allow-agent-to-exit/specs/pseudo-terminal/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Continue triggers
+
+The PTY layer SHALL intercept continue triggers from two sources: user input (`/next` typed on a line followed by Enter, or a keyboard shortcut) and agent output (a designated sentinel escape sequence). When any trigger is detected, the runner signals the CLI to terminate and advances to the next workflow step.
+
+#### Scenario: /next typed
+- **WHEN** the user types `/next` and presses Enter during an interactive step
+- **THEN** the runner terminates the CLI process and advances to the next step with outcome success
+
+#### Scenario: Keyboard shortcut pressed
+- **WHEN** the user presses the continue keyboard shortcut during an interactive step
+- **THEN** the runner terminates the CLI process and advances to the next step with outcome success
+
+#### Scenario: Continue trigger not forwarded to CLI
+- **WHEN** the user types `/next` or presses the continue keyboard shortcut
+- **THEN** the typed bytes are intercepted by the PTY layer and not delivered to the CLI process as input
+
+#### Scenario: Agent emits sentinel
+- **WHEN** the agent writes the designated sentinel escape sequence to stdout during an interactive step
+- **THEN** the runner terminates the CLI process and advances to the next step with outcome success
+
+#### Scenario: Agent sentinel not forwarded
+- **WHEN** the agent writes the designated sentinel escape sequence to stdout
+- **THEN** the sentinel bytes are stripped from the output and not displayed on the user's terminal

--- a/openspec/changes/allow-agent-to-exit/tasks.md
+++ b/openspec/changes/allow-agent-to-exit/tasks.md
@@ -1,1 +1,1 @@
-- [ ] Add agent-initiated continue trigger (`tasks/agent-continue-trigger.md`)
+- [x] Add agent-initiated continue trigger (`tasks/agent-continue-trigger.md`)

--- a/openspec/changes/allow-agent-to-exit/tasks.md
+++ b/openspec/changes/allow-agent-to-exit/tasks.md
@@ -1,0 +1,1 @@
+- [ ] Add agent-initiated continue trigger (`tasks/agent-continue-trigger.md`)

--- a/openspec/changes/allow-agent-to-exit/tasks/agent-continue-trigger.md
+++ b/openspec/changes/allow-agent-to-exit/tasks/agent-continue-trigger.md
@@ -1,0 +1,69 @@
+# Task: Add Agent-Initiated Continue Trigger
+
+## Goal
+
+Enable agents to signal task completion by emitting a sentinel escape sequence in stdout, triggering the same continue and termination protocol as the user-initiated `/next`. This is the full vertical slice: output processor, PTY wiring, prompt injection, and tests.
+
+## Background
+
+You MUST read these files before starting:
+- `openspec/changes/allow-agent-to-exit/design.md` — full design details (see "Approach" section for architecture, "Decisions" table for rationale)
+- `openspec/changes/allow-agent-to-exit/specs/agent-continue-trigger/spec.md` — "Requirement: Agent-initiated continue via stdout sentinel" and "Requirement: Sentinel instruction injection" for acceptance criteria
+- `openspec/changes/allow-agent-to-exit/specs/pseudo-terminal/spec.md` — "Requirement: Continue triggers" (modified) for updated trigger requirements
+
+**Key files to study:**
+- `internal/pty/input.go` — the existing `inputProcessor` is the direct template for the new output processor. Study its state machine and `processResult` structure.
+- `internal/pty/pty.go` — `forwardOutput` (output path to modify) and `processStdin` (reference for trigger + termination logic)
+- `internal/exec/agent.go` — `ExecuteAgentStep` where prompt injection should happen
+- `internal/pty/input_test.go` and `internal/exec/agent_test.go` — test conventions to follow
+
+**What to build:**
+1. An `outputProcessor` in a new file `internal/pty/output.go` — a byte-by-byte state machine that detects the sentinel OSC sequence `\x1b]999;red-slippers\x07` in the output stream, strips it, and signals a trigger. Must handle chunk boundary splits via persistent state. Non-matching OSC sequences and partial sentinels at EOF must be flushed as normal output.
+2. Wire the output processor into `forwardOutput`, giving it access to the same termination infrastructure as `processStdin` so it can fire the continue protocol on detection.
+3. Auto-inject sentinel instructions into interactive step prompts (not headless) in `ExecuteAgentStep`.
+
+## Spec
+
+### Requirement: Agent-initiated continue via stdout sentinel
+
+The PTY layer SHALL detect a designated sentinel escape sequence in the agent's stdout output. When detected, the sentinel SHALL be stripped from the output (never forwarded to the terminal) and the runner SHALL trigger the existing continue and termination protocol, advancing to the next workflow step with outcome success — identical to a user-initiated `/next`.
+
+#### Scenario: Agent emits sentinel
+- **WHEN** the agent writes the sentinel sequence to stdout during an interactive step
+- **THEN** the runner triggers continue and advances to the next step with outcome success
+
+#### Scenario: Sentinel stripped from output
+- **WHEN** the agent writes the sentinel sequence to stdout
+- **THEN** the sentinel bytes are not displayed on the user's terminal
+
+#### Scenario: Sentinel embedded in other output
+- **WHEN** the agent writes the sentinel surrounded by other output bytes in the same write
+- **THEN** only the sentinel is stripped; surrounding output is forwarded to the terminal normally
+
+#### Scenario: Sentinel detection across chunk boundaries
+- **WHEN** the sentinel sequence arrives split across PTY read chunks
+- **THEN** the output processor detects and strips the sentinel
+
+#### Scenario: Incomplete sentinel at process exit
+- **WHEN** the agent writes a partial sentinel sequence and the process exits before the sequence is completed
+- **THEN** the buffered partial bytes are flushed to the terminal as normal output
+
+#### Scenario: Non-matching OSC sequence passed through
+- **WHEN** the agent writes an OSC sequence that does not match the sentinel payload
+- **THEN** the entire OSC sequence is forwarded to the terminal as normal output
+
+### Requirement: Sentinel instruction injection
+
+The runner SHALL automatically append sentinel completion instructions to the prompt for all interactive agent steps. Headless steps SHALL NOT receive the instruction.
+
+#### Scenario: Interactive step receives sentinel instruction
+- **WHEN** the runner builds the prompt for an interactive agent step
+- **THEN** the prompt includes an instruction telling the agent how to emit the sentinel
+
+#### Scenario: Headless step does not receive sentinel instruction
+- **WHEN** the runner builds the prompt for a headless agent step
+- **THEN** the prompt does not include the sentinel instruction
+
+## Done When
+
+All eight spec scenarios above are covered by tests and passing. The output processor correctly detects, strips, and triggers on the sentinel (including edge cases: chunk splits, partial at EOF, non-matching OSC). Interactive step prompts include the sentinel instruction; headless prompts do not. All existing tests continue to pass.

--- a/workflows/implement-change.yaml
+++ b/workflows/implement-change.yaml
@@ -29,5 +29,5 @@ steps:
     mode: headless
     session: resume
     prompt: |
-      Help me finalize the PR.
+      Help the user finalize the PR.
       You MUST use the codagent:finalize-pr skill.

--- a/workflows/plan-change.yaml
+++ b/workflows/plan-change.yaml
@@ -10,6 +10,11 @@ engine:
   change_param: change_name
 
 steps:
+  - id: check-clean
+    mode: shell
+    # agent-validator detect: exit 0 = unvalidated changes present, exit 2 = clean (no changes)
+    command: "agent-validator detect; status=$?; if [ $status -eq 2 ]; then exit 0; elif [ $status -eq 0 ]; then echo 'Unvalidated changes detected. Run agent-validator before planning.' >&2; exit 1; else exit $status; fi"
+
   - id: create
     mode: shell
     command: openspec new change "{{change_name}}"
@@ -64,3 +69,7 @@ steps:
     prompt: |
       Run `openspec validate --type change "{{change_name}}"` and fix every issue it reports.
       Keep running the command and fixing until it passes with no errors.
+
+  - id: skip-validator
+    mode: shell
+    command: agent-validator skip

--- a/workflows/plan-change.yaml
+++ b/workflows/plan-change.yaml
@@ -23,30 +23,30 @@ steps:
     mode: interactive
     session: resume
     prompt: |
-      Help me write a change proposal.
+      Help the user write a change proposal.
       You MUST use the codagent:propose skill.
 
-      Before doing anything else, ask me to describe what this change is about and what I want to accomplish.
+      Before doing anything else, ask the user to describe what this change is about and what they want to accomplish.
 
   - id: specs
     mode: interactive
     session: resume
     prompt: |
-      Help me write the change spec.
+      Help the user write the change spec.
       You MUST use the codagent:spec skill.
 
   - id: design
     mode: interactive
     session: resume
     prompt: |
-      Help me design the change.
+      Help the user design the change.
       You MUST use the codagent:design skill.
 
   - id: tasks
     mode: interactive
     session: resume
     prompt: |
-      Help me plan tasks for the change.
+      Help the user plan tasks for the change.
       You MUST use the codagent:plan-tasks skill.
 
   - id: pre-review-validate

--- a/workflows/run-validator.yaml
+++ b/workflows/run-validator.yaml
@@ -34,8 +34,9 @@ steps:
           Read the full log file if the summary lacks context.
 
           If the output below lacks detail (e.g. just "Status: error"),
-          read the validator debug log at validator_logs/.debug.log for
-          the full error context before attempting any fixes.
+          first inspect captured STDERR (if present). If detail is still
+          insufficient and validator_logs/.debug.log exists, read it for
+          full error context before attempting fixes.
 
           When you are done fixing, commit your changes with a clear,
           descriptive commit message. Then summarize to the user what

--- a/workflows/run-validator.yaml
+++ b/workflows/run-validator.yaml
@@ -10,6 +10,7 @@ steps:
         mode: shell
         command: agent-validator run --report --enable-review task-compliance
         capture: validator_output
+        capture_stderr: true
         continue_on_failure: true
         break_if: success
 
@@ -31,6 +32,10 @@ steps:
           To skip a review violation:
             agent-validator update-review skip <#> "why"
           Read the full log file if the summary lacks context.
+
+          If the output below lacks detail (e.g. just "Status: error"),
+          read the validator debug log at validator_logs/.debug.log for
+          the full error context before attempting any fixes.
 
           When you are done fixing, commit your changes with a clear,
           descriptive commit message. Then summarize to the user what


### PR DESCRIPTION
## Summary

- Add agent-initiated continue trigger: the PTY output path detects a sentinel OSC escape sequence (`\x1b]999;red-slippers\x07`) emitted by the agent's stdout and triggers the same continue logic as `/next` or Ctrl-]
- Introduce an output processor that scans PTY output for the sentinel, strips it before forwarding to the terminal, and fires `tryTriggerContinue()`
- Guard the output processor against memory growth with bounded escape-sequence buffering and overflow flushing
- Route full prompt to system prompt for interactive steps; append sentinel instructions automatically so workflow authors need zero changes
- Continue draining PTY output after sentinel detection so the child process doesn't block on a full buffer
- Propagate step.Workdir to interactive PTY sessions
- Validate capture_stderr/workdir field combinations
- Handle stdout write errors consistently across all output paths

Also includes prior accumulated work: system prompt routing, PTY fixes, validator rename (gauntlet → validator), CLI simplification, CI workflow, and various bug fixes.

## Key changes

- `internal/pty/output.go` — output processor that buffers and scans for the sentinel across chunk boundaries
- `internal/pty/pty.go` — wire output processor into PTY goroutines; extracted `forwardChunk`/`flushToStdout`/`beginTermination`/`writeStdout` helpers for complexity and error handling
- `internal/exec/agent.go` — auto-append sentinel instructions to interactive step prompts; pass Workdir to PTY options
- `internal/model/step.go` — validate capture_stderr requires capture; workdir only on shell/agent steps
- `.validator/config.yml` — renamed from `.gauntlet/`, updated config format
- `.github/workflows/ci.yml` — new CI workflow

## Test plan

- [ ] Verify agent can emit sentinel and trigger step transition without user input
- [ ] Verify sentinel is stripped from terminal display output
- [ ] Verify user-initiated `/next` and Ctrl-] still work unchanged
- [ ] Verify output processor handles sentinel split across chunk boundaries
- [ ] Verify bounded buffer prevents memory growth on malformed escape sequences
- [ ] Verify interactive steps honor workdir when set
- [ ] CI passes (build, lint, test, security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive agents can autonomously signal completion to advance workflows.
  * Steps can run in a configured working directory (workdir) and optionally capture stderr alongside stdout.

* **Configuration**
  * Default review adapter changed to GitHub Copilot (replacing prior adapters).

* **Improvements**
  * Better validator integration and diagnostics in workflows; improved prompt routing and headless error detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->