### PR TITLE
fix: resolve builtin workflows when running from any directory

### DIFF
--- a/internal/runview/resolve.go
+++ b/internal/runview/resolve.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/codagent/agent-runner/internal/model"
+	builtinworkflows "github.com/codagent/agent-runner/workflows"
 )
 
 // ResolvedWorkflow is the output of ResolveWorkflow: the absolute path to
@@ -54,6 +55,15 @@ func ResolveWorkflow(sessionDir, projectDir string, state *model.RunState) (Reso
 	}
 
 	out := ResolvedWorkflow{OriginCwd: origin}
+
+	// (0) — builtin workflow embedded in the binary; no filesystem lookup needed.
+	if builtinworkflows.IsRef(state.WorkflowFile) {
+		if _, err := builtinworkflows.ReadFile(state.WorkflowFile); err == nil {
+			out.AbsPath = state.WorkflowFile
+			out.WorkflowsRoot, out.RepoRoot = rootsFromBases(bases)
+			return out, true
+		}
+	}
 
 	// (1)/(2)/(3) — direct path resolution from state.WorkflowFile.
 	if p, ok := tryDirectFile(state.WorkflowFile, bases); ok {

--- a/internal/runview/resolve_test.go
+++ b/internal/runview/resolve_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/codagent/agent-runner/internal/model"
+	builtinworkflows "github.com/codagent/agent-runner/workflows"
 )
 
 // writeFile is a tiny t.Fatal-on-error helper used throughout the resolver
@@ -411,6 +412,59 @@ func TestResolveWorkflow_DiscoveryByName_AgentRunnerWorkflowsDir(t *testing.T) {
 	}
 	if got.AbsPath != filepath.Clean(wfPath) {
 		t.Fatalf("AbsPath = %q, want %q", got.AbsPath, wfPath)
+	}
+}
+
+func TestResolveWorkflow_BuiltinRef(t *testing.T) {
+	base := realPath(t, t.TempDir())
+	projectDir := filepath.Join(base, "projects", "encoded")
+	sessionDir := filepath.Join(projectDir, "runs", "change-2026-04-11T09-14-00-000000000Z")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// No meta.json, process cwd is unrelated — forces the resolver to
+	// recognise the builtin: prefix without any filesystem search.
+	chdirTo(t, realPath(t, t.TempDir()))
+
+	// Pick a builtin workflow that we know is embedded.
+	ref := builtinworkflows.Ref("openspec/change.yaml")
+
+	state := model.RunState{WorkflowFile: ref, WorkflowName: "change"}
+	got, ok := ResolveWorkflow(sessionDir, projectDir, &state)
+	if !ok {
+		t.Fatalf("expected ResolveWorkflow to succeed for builtin ref %q", ref)
+	}
+	if got.AbsPath != ref {
+		t.Fatalf("AbsPath = %q, want %q", got.AbsPath, ref)
+	}
+}
+
+func TestNew_BuiltinWorkflowShowsSteps(t *testing.T) {
+	base := realPath(t, t.TempDir())
+	projectDir := filepath.Join(base, "projects", "encoded")
+	sessionDir := filepath.Join(projectDir, "runs", "change-2026-04-11T09-14-00-000000000Z")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	ref := builtinworkflows.Ref("openspec/change.yaml")
+	state := model.RunState{WorkflowFile: ref, WorkflowName: "change"}
+	data, _ := json.Marshal(state)
+	writeFile(t, filepath.Join(sessionDir, "state.json"), string(data))
+	chdirTo(t, realPath(t, t.TempDir()))
+
+	m, err := New(sessionDir, projectDir, FromList)
+	if err != nil {
+		t.Fatalf("runview.New: %v", err)
+	}
+	if m.loadErr != "" {
+		t.Fatalf("unexpected load error: %s", m.loadErr)
+	}
+	if m.tree == nil || m.tree.Root == nil {
+		t.Fatal("expected a populated tree")
+	}
+	if len(m.tree.Root.Children) == 0 {
+		t.Fatal("expected steps in tree but got none (\"No steps to display\" bug)")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `ResolveWorkflow` did not handle the `builtin:` prefix in `state.WorkflowFile`, causing all builtin workflows (`openspec:change`, etc.) to show "No steps to display" when `agent-runner` was invoked outside the project root
- Added early return in `ResolveWorkflow` that checks for `builtin:` refs and resolves them from the embedded FS directly, bypassing filesystem search
- Added unit test for `ResolveWorkflow` and end-to-end test for `runview.New` with builtin refs

## Test plan
- [x] `TestResolveWorkflow_BuiltinRef` — verifies builtin ref resolves without filesystem
- [x] `TestNew_BuiltinWorkflowShowsSteps` — verifies the full runview model shows steps for a builtin workflow
- [x] Full test suite passes (`go test ./...`)
- [x] Validator passed (build, lint, test, security, code review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflows can now use embedded builtin references, allowing users to leverage predefined workflow templates that are automatically resolved and displayed in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->