### PR TITLE
Add Windows support

### DIFF
--- a/cmd/agent-runner/execself_unix.go
+++ b/cmd/agent-runner/execself_unix.go
@@ -1,0 +1,12 @@
+//go:build linux || darwin
+
+package main
+
+import "syscall"
+
+// execProcessImpl on Unix is syscall.Exec — the current process is replaced
+// in place with the named program. Used by execSelf to re-launch agent-runner
+// (e.g. after onboarding or theme changes) without leaving a stranded parent.
+func execProcessImpl(argv0 string, argv []string, envv []string) error {
+	return syscall.Exec(argv0, argv, envv)
+}

--- a/cmd/agent-runner/execself_windows.go
+++ b/cmd/agent-runner/execself_windows.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+)
+
+// execProcessImpl on Windows emulates the Unix exec(2) semantics by spawning
+// the named program as a child process, waiting for it to exit, and calling
+// os.Exit with its exit code. Windows has no in-place process replacement
+// equivalent to syscall.Exec.
+//
+// argv0 is the absolute path to the executable. argv[0] is the program name
+// the caller wants the child to see (typically filepath.Base(argv0)) and
+// argv[1:] are the arguments. envv is the full environment to apply.
+//
+// Note: this never returns under normal conditions — it terminates the
+// current process via os.Exit. It only returns an error when the child
+// could not be started, mirroring the Unix syscall.Exec contract where a
+// non-nil return means the exec syscall itself failed.
+func execProcessImpl(argv0 string, argv []string, envv []string) error {
+	if len(argv) == 0 {
+		return errors.New("execProcess: argv must contain at least the program name")
+	}
+	cmd := exec.Command(argv0, argv[1:]...) // #nosec G204 -- argv0 is our own executable
+	cmd.Env = envv
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	waitErr := cmd.Wait()
+	exitCode := 0
+	if waitErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = 1
+		}
+	}
+	os.Exit(exitCode)
+	return nil // unreachable
+}

--- a/cmd/agent-runner/main.go
+++ b/cmd/agent-runner/main.go
@@ -14,7 +14,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -50,7 +49,12 @@ var version = "dev"
 
 var userHomeDir = os.UserHomeDir
 var currentExecutable = os.Executable
-var execProcess = syscall.Exec
+
+// execProcess replaces the current process with the named program. On Unix
+// it is wired to syscall.Exec. Windows lacks an exec(2) equivalent, so
+// execProcess_windows.go emulates it by spawning a child and exiting with
+// the child's exit code.
+var execProcess = execProcessImpl
 
 const liveRunImmediateAltScreenEnv = "AGENT_RUNNER_LIVE_RUN_IMMEDIATE_ALT_SCREEN"
 const agentRunnerExecutableEnv = "AGENT_RUNNER_EXECUTABLE"

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -80,11 +80,14 @@ func BuildPrefix(nestingPath []NestingInfo, stepID string) string {
 	return "[" + strings.Join(tokens, ", ") + "]"
 }
 
-var pathUnsafeRe = regexp.MustCompile(`[/._]`)
+var pathUnsafeRe = regexp.MustCompile(`[/._:\\]`)
 var fileUnsafeRe = regexp.MustCompile(`[\\/:*?"<>|]`)
 
-// EncodePath replaces path-unsafe characters (/, ., _) with dashes for use
-// in directory names under ~/.agent-runner/projects/.
+// EncodePath replaces path-unsafe characters (/, ., _, :, \) with dashes for
+// use in directory names under ~/.agent-runner/projects/. The backslash and
+// colon are required for Windows paths (e.g. C:\dev\appacadabra), which
+// cannot otherwise be used as a single directory name. On Unix paths these
+// characters do not appear, so the encoding remains stable.
 func EncodePath(dirPath string) string {
 	return pathUnsafeRe.ReplaceAllString(dirPath, "-")
 }

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -60,6 +60,13 @@ func TestEncodePath(t *testing.T) {
 			t.Fatalf("expected 'my-project-v2', got %q", result)
 		}
 	})
+
+	t.Run("replaces windows drive colon and backslashes", func(t *testing.T) {
+		result := EncodePath(`C:\dev\appacadabra`)
+		if result != "C--dev-appacadabra" {
+			t.Fatalf("expected 'C--dev-appacadabra', got %q", result)
+		}
+	})
 }
 
 func TestSanitizeWorkflowName(t *testing.T) {

--- a/internal/exec/shell.go
+++ b/internal/exec/shell.go
@@ -11,13 +11,14 @@ import (
 	"github.com/codagent/agent-runner/internal/flowctl"
 	"github.com/codagent/agent-runner/internal/model"
 	"github.com/codagent/agent-runner/internal/pty"
+	"github.com/codagent/agent-runner/internal/shellcmd"
 	"github.com/codagent/agent-runner/internal/textfmt"
 )
 
 // runSkipShell runs a skip_if shell expression and returns its exit code.
 // Overridden in tests to avoid spawning subprocesses.
 var runSkipShell = func(cmd string) (int, error) {
-	c := exec.Command("sh", "-c", cmd) // #nosec G204 -- skip_if command comes from workflow YAML
+	c := shellcmd.New(cmd)
 	err := c.Run()
 	if err == nil {
 		return 0, nil

--- a/internal/liverun/process_runner.go
+++ b/internal/liverun/process_runner.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	iexec "github.com/codagent/agent-runner/internal/exec"
+	"github.com/codagent/agent-runner/internal/shellcmd"
 )
 
 // PrefixSetter is implemented by TUIProcessRunner. The exec package uses this
@@ -197,7 +198,7 @@ func (r *tuiProcessRunner) compositeWriter(stream, ext string, buf *bytes.Buffer
 // persisting raw bytes to output files. Behaves identically to realProcessRunner
 // from the caller's perspective; ProcessResult is always populated.
 func (r *tuiProcessRunner) RunShell(cmd string, captureStdout bool, workdir string) (iexec.ProcessResult, error) {
-	c := exec.Command("sh", "-c", cmd) // #nosec G204
+	c := shellcmd.New(cmd)
 	c.Stdin = os.Stdin
 	if workdir != "" {
 		c.Dir = filepath.Clean(workdir) // #nosec G304

--- a/internal/pty/hint_test.go
+++ b/internal/pty/hint_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package pty
 
 import (

--- a/internal/pty/hint_unix.go
+++ b/internal/pty/hint_unix.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package pty
 
 import (

--- a/internal/pty/pty_test.go
+++ b/internal/pty/pty_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package pty
 
 import (

--- a/internal/pty/pty_unix.go
+++ b/internal/pty/pty_unix.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package pty
 
 import (
@@ -23,24 +25,6 @@ const (
 	killTimeout = 3 * time.Second
 	stdinPollMs = 100 // poll timeout in ms for cancellable stdin reads
 )
-
-// Result holds the outcome of an interactive PTY session.
-type Result struct {
-	ExitCode          int
-	ContinueTriggered bool
-	// Stdout is a transcript of bytes the PTY emitted during the session, with
-	// ANSI escape sequences stripped. Populated for shell interactive sessions
-	// so callers can surface what scrolled past after the session ends.
-	Stdout string
-}
-
-// Options configures an interactive PTY session.
-type Options struct {
-	Env            []string // additional environment variables
-	Workdir        string   // working directory for the child process
-	DebugLabel     string   // optional human-readable context for PTY debug logs
-	ContinueMarker string   // optional plain-text continuation marker accepted from PTY output
-}
 
 // ptyState holds shared mutable state for a PTY session.
 type ptyState struct {

--- a/internal/pty/pty_windows.go
+++ b/internal/pty/pty_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package pty
+
+import "errors"
+
+// errInteractiveUnsupported is returned by RunInteractive and
+// RunShellInteractive on Windows builds. The Windows port of agent-runner
+// currently supports only autonomous and command steps; interactive PTY
+// steps require ConPTY plumbing that is not yet implemented.
+//
+// Workflow authors targeting Windows should set `mode: autonomous` on
+// agent steps and rely on plain shell steps for shell commands. The
+// upstream Unix builds retain full interactive support.
+var errInteractiveUnsupported = errors.New(
+	"pty: interactive mode is not yet supported on Windows; " +
+		"use mode: autonomous on agent steps or run a non-interactive shell step",
+)
+
+// RunInteractive is a Windows stub that returns errInteractiveUnsupported.
+// See pty_unix.go for the Linux/macOS implementation.
+func RunInteractive(args []string, opts Options) (Result, error) {
+	_ = args
+	_ = opts
+	return Result{}, errInteractiveUnsupported
+}
+
+// RunShellInteractive is a Windows stub that returns errInteractiveUnsupported.
+// See pty_unix.go for the Linux/macOS implementation.
+func RunShellInteractive(command string, opts Options) (Result, error) {
+	_ = command
+	_ = opts
+	return Result{}, errInteractiveUnsupported
+}

--- a/internal/pty/transcript_test.go
+++ b/internal/pty/transcript_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package pty
 
 import (

--- a/internal/pty/types.go
+++ b/internal/pty/types.go
@@ -1,0 +1,20 @@
+package pty
+
+// Result holds the outcome of an interactive PTY session.
+//
+// Stdout is a transcript of bytes the PTY emitted during the session, with
+// ANSI escape sequences stripped. Populated for shell interactive sessions
+// so callers can surface what scrolled past after the session ends.
+type Result struct {
+	ExitCode          int
+	ContinueTriggered bool
+	Stdout            string
+}
+
+// Options configures an interactive PTY session.
+type Options struct {
+	Env            []string // additional environment variables
+	Workdir        string   // working directory for the child process
+	DebugLabel     string   // optional human-readable context for PTY debug logs
+	ContinueMarker string   // optional plain-text continuation marker accepted from PTY output
+}

--- a/internal/shellcmd/shellcmd_unix.go
+++ b/internal/shellcmd/shellcmd_unix.go
@@ -1,0 +1,19 @@
+//go:build linux || darwin
+
+// Package shellcmd provides a cross-platform constructor for "run this string
+// through the system shell" commands. On Linux and macOS the command is run
+// via `sh -c <string>`. On Windows it is run via `cmd.exe /C <string>`.
+//
+// Workflow YAMLs are expected to use POSIX shell syntax. Workflows that rely
+// on bash builtins or shell features that are not present in cmd.exe (here
+// strings, process substitution, exported function names, etc.) will fail on
+// Windows; that is a workflow portability issue, not a shellcmd issue.
+package shellcmd
+
+import "os/exec"
+
+// New builds an *exec.Cmd that executes the given command string through the
+// platform shell.
+func New(command string) *exec.Cmd {
+	return exec.Command("sh", "-c", command) // #nosec G204 -- caller-controlled workflow command
+}

--- a/internal/shellcmd/shellcmd_windows.go
+++ b/internal/shellcmd/shellcmd_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+// Package shellcmd provides a cross-platform constructor for "run this string
+// through the system shell" commands. See shellcmd_unix.go for the Unix
+// implementation and the portability caveat.
+package shellcmd
+
+import "os/exec"
+
+// New builds an *exec.Cmd that executes the given command string through
+// cmd.exe. The /C flag tells cmd.exe to terminate after the command runs.
+func New(command string) *exec.Cmd {
+	return exec.Command("cmd.exe", "/C", command) // #nosec G204 -- caller-controlled workflow command
+}


### PR DESCRIPTION
## Summary

Make agent-runner build and run on Windows. Autonomous agent steps and shell command steps work natively; interactive PTY mode is stubbed behind a clear error pending a ConPTY-backed implementation. Linux and macOS behavior is unchanged.

## Changes

**internal/pty — platform split**
- Add `//go:build linux || darwin` to `pty.go` (renamed `pty_unix.go`) and `hint.go` (renamed `hint_unix.go`). Unix implementation unchanged.
- Extract shared `Result` and `Options` types into `types.go` (no build tag).
- Add `pty_windows.go` with stub `RunInteractive` and `RunShellInteractive` returning `"pty: interactive mode is not yet supported on Windows; use mode: autonomous"`. Autonomous and command steps are unaffected.
- Tag `pty_test.go`, `hint_test.go`, `transcript_test.go` as Unix-only since they exercise symbols moved into the tagged files.

**internal/shellcmd — new package**
- `shellcmd.New(command)` returns `exec.Command("sh", "-c", ...)` on Linux/macOS and `exec.Command("cmd.exe", "/C", ...)` on Windows.

**Call-site changes**
- `internal/exec/shell.go` `runSkipShell` and `internal/liverun/process_runner.go` `RunShell` use `shellcmd.New` instead of literal `"sh", "-c"`.

**cmd/agent-runner — exec-self platform split**
- Replace `var execProcess = syscall.Exec` (Unix-only) with `var execProcess = execProcessImpl`.
- `execself_unix.go` delegates to `syscall.Exec`.
- `execself_windows.go` emulates exec by spawning the child, waiting, and calling `os.Exit` with the child's code. Drops the `"syscall"` import from `main.go`.

**internal/audit — path encoding for Windows drives**
- `EncodePath` regex extended from `[/._]` to `[/._:\\]` so `C:\dev\my-project` encodes as `C--dev-my-project` instead of failing `MkdirAll` with `mkdir ...\projects\C:: invalid syntax`.

## Verified

- `go vet ./...` passes on linux, darwin, windows
- `go build ./...` passes on all three platforms
- Windows test suite: `internal/pty`, `internal/shellcmd`, `internal/audit` green. Remaining pre-existing Windows failures in `internal/exec` and `internal/liverun` are unrelated to this PR (Claude session-dir encoding embedding raw cwd, `RunScript` exec-ing `.sh` directly, `skip_if` expressions using POSIX-only syntax) — flagged below for follow-up.
- End-to-end smoke test on Windows: `agent-runner.exe bugfix bug_summary="..."` launches the TUI and starts the workflow against a real `.agent-runner/` config.

## Known Windows runtime limitations (follow-up PRs)

- Interactive PTY mode is stubbed. Workflows on Windows must use `mode: autonomous` on agent steps.
- `skip_if: sh:...` expressions run via `cmd.exe /C`, not `sh -c`. POSIX shell features unavailable.
- `RunScript` cannot exec `.sh` scripts directly. Use `bash script.sh` (WSL/git-bash on PATH) or `.bat`.

## Test plan

- [x] `go vet ./...` clean on linux, darwin, windows
- [x] `go build ./cmd/agent-runner` succeeds on linux, darwin, windows
- [x] `go test ./internal/audit/... ./internal/pty/... ./internal/shellcmd/...` green on all three
- [x] On Windows: `agent-runner.exe -validate <workflow>` succeeds; running a workflow creates `~/.agent-runner/projects/<encoded>/runs/<id>/`
- [x] On Linux: existing CI suite continues to pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows platform support for process execution and shell command handling, enabling cross-platform compatibility.

* **Bug Fixes**
  * Improved path encoding to correctly handle Windows-specific characters in project paths.

* **Tests**
  * Expanded test coverage with scenarios for Windows path encoding validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->