### PR TITLE
chore: connect factory routing

### DIFF
--- a/.github/workflows/factory-routing.yml
+++ b/.github/workflows/factory-routing.yml
@@ -11,8 +11,8 @@ permissions:
 
 jobs:
   route:
-    uses: Codagent-AI/agent-factory/.github/workflows/route-work.yml@46c6bdee1858cd9925e1658a9d8c7c92402edb78
+    uses: Codagent-AI/agent-factory/.github/workflows/route-work.yml@fef62baa563b7e80572b44d0aa9f43508b5a3243
     with:
-      factory-revision: 46c6bdee1858cd9925e1658a9d8c7c92402edb78
+      factory-revision: fef62baa563b7e80572b44d0aa9f43508b5a3243
     secrets:
       factory-app-private-key: ${{ secrets.FACTORY_APP_PRIVATE_KEY }}

--- a/.github/workflows/factory-routing.yml
+++ b/.github/workflows/factory-routing.yml
@@ -1,0 +1,18 @@
+name: Factory routing
+
+on:
+  issues:
+    types: [opened, reopened, edited, closed, labeled, unlabeled]
+  pull_request:
+    types: [opened, reopened, edited, closed, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  route:
+    uses: Codagent-AI/agent-factory/.github/workflows/route-work.yml@46c6bdee1858cd9925e1658a9d8c7c92402edb78
+    with:
+      factory-revision: 46c6bdee1858cd9925e1658a9d8c7c92402edb78
+    secrets:
+      factory-app-private-key: ${{ secrets.FACTORY_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Issue and pull-request events invoke the shared Agent Factory routing workflow pinned to `fef62baa563b7e80572b44d0aa9f43508b5a3243`. Routing adds configured work to the Codagent Project and initializes its fields once; ordinary work enters Backlog, while authorized eval requests enter Ready with factory ownership.

Validation: actionlint passed for the caller. The pinned factory passed Agent Validator (92 tests passed, one optional Docker test skipped; build, lint, typecheck and reviews passed). Required App secret and ID variable are present; routing labels are configured.

Deployment: merge this small PR into `main` to enable issue-event routing. Live acceptance remains pending. Local factory admission remains paused.


The first routing check exposed a malformed Project lookup query in the shared factory. The updated pin includes its regression-tested fix; routing is rechecked on this PR update.
