### PR TITLE
fix: deploy factory issue event parsing

### DIFF
--- a/.github/workflows/factory-routing.yml
+++ b/.github/workflows/factory-routing.yml
@@ -11,8 +11,8 @@ permissions:
 
 jobs:
   route:
-    uses: Codagent-AI/agent-factory/.github/workflows/route-work.yml@fef62baa563b7e80572b44d0aa9f43508b5a3243
+    uses: Codagent-AI/agent-factory/.github/workflows/route-work.yml@1b527969f8160cf336aa1258c424c3ad4ec7c7c7
     with:
-      factory-revision: fef62baa563b7e80572b44d0aa9f43508b5a3243
+      factory-revision: 1b527969f8160cf336aa1258c424c3ad4ec7c7c7
     secrets:
       factory-app-private-key: ${{ secrets.FACTORY_APP_PRIVATE_KEY }}

--- a/.github/workflows/factory-routing.yml
+++ b/.github/workflows/factory-routing.yml
@@ -11,8 +11,8 @@ permissions:
 
 jobs:
   route:
-    uses: Codagent-AI/agent-factory/.github/workflows/route-work.yml@1b527969f8160cf336aa1258c424c3ad4ec7c7c7
+    uses: Codagent-AI/agent-factory/.github/workflows/route-work.yml@0e7e5074aa7b0b57f266c1225f708b29a55481d4
     with:
-      factory-revision: 1b527969f8160cf336aa1258c424c3ad4ec7c7c7
+      factory-revision: 0e7e5074aa7b0b57f266c1225f708b29a55481d4
     secrets:
       factory-app-private-key: ${{ secrets.FACTORY_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Real issue events put their number under issue.number; existing Project cards also contain unselected field types that GitHub returns as empty objects. The updated factory pin `0e7e5074aa7b0b57f266c1225f708b29a55481d4` handles both cases, restoring issue routing, repeat deliveries and queue reading.

Only two SHA references in this caller change. Regression tests reproduced both defects before the fixes. Full Agent Validator passed: 96 tests passed, one optional Docker skip; build, lint, typecheck and all reviews passed. Independent AT-001/AT-002 verification follows deployment.
